### PR TITLE
Fix downloads getting automatically deleted by android

### DIFF
--- a/app/src/main/java/dev/jdtech/jellyfin/utils/DownloadUtilities.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/DownloadUtilities.kt
@@ -29,6 +29,7 @@ fun requestDownload(uri: Uri, downloadRequestItem: DownloadRequestItem, context:
                 )
             )
         )
+        .setVisibleInDownloadsUi(true)
         .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
     if (!File(defaultStorage, downloadRequestItem.itemId.toString()).exists())
         downloadFile(downloadRequest, context)


### PR DESCRIPTION
Fixed a bug where android would automatically delete downloads because it assumed that findroid had forgotten about them.