### PR TITLE
Add option to turn off subtitles

### DIFF
--- a/app/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -135,6 +135,8 @@ class PlayerActivity : BasePlayerActivity() {
                         this, resources.getString(R.string.select_subtile_track),
                         viewModel.trackSelector, subtitleRenderer
                     )
+                    trackSelectionDialogBuilder.setShowDisableOption(true)
+
                     val trackSelectionDialog = trackSelectionDialogBuilder.build()
                     trackSelectionDialog.show()
                 }


### PR DESCRIPTION
I added the option to turn off the subtitles for a video which has subtitles enabled by default. Turns out you just have to enable the `ShowDisableOption` in the `TrackSelectionDialogBuilder`.

This fixes #82.

Here is a screenshot of the new option ("Ohne" = None, my phone is set to German).
![Screenshot_20220301-163636](https://user-images.githubusercontent.com/19636565/156199259-9bfe5be2-228d-430f-a9e0-7d76f8c6916b.jpg)
