### PR TITLE
Extra settings

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,3 +26,11 @@
 -keep class is.xyz.libmpv.MPVLib {
   *;
 }
+
+# ProGuard thinks all SettingsFragments are unused
+-keep class dev.jdtech.jellyfin.fragments.SettingsLanguageFragment
+-keep class dev.jdtech.jellyfin.fragments.SettingsAppearanceFragment
+-keep class dev.jdtech.jellyfin.fragments.SettingsDownloadsFragment
+-keep class dev.jdtech.jellyfin.fragments.SettingsPlayerFragment
+-keep class dev.jdtech.jellyfin.fragments.SettingsDeviceFragment
+-keep class dev.jdtech.jellyfin.fragments.SettingsCacheFragment

--- a/app/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -31,7 +31,7 @@ class PlayerActivity : BasePlayerActivity() {
     lateinit var appPreferences: AppPreferences
 
     lateinit var binding: ActivityPlayerBinding
-    private lateinit var playerGestureHelper: PlayerGestureHelper
+    private var playerGestureHelper: PlayerGestureHelper? = null
     override val viewModel: PlayerActivityViewModel by viewModels()
     private val args: PlayerActivityArgs by navArgs()
 
@@ -49,12 +49,14 @@ class PlayerActivity : BasePlayerActivity() {
 
         configureInsets(playerControls)
 
-        playerGestureHelper = PlayerGestureHelper(
-            appPreferences,
-            this,
-            binding.playerView,
-            getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        )
+        if (appPreferences.playerGestures) {
+            playerGestureHelper = PlayerGestureHelper(
+                appPreferences,
+                this,
+                binding.playerView,
+                getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            )
+        }
 
         binding.playerView.findViewById<View>(R.id.back_button).setOnClickListener {
             onBackPressed()

--- a/app/src/main/java/dev/jdtech/jellyfin/di/GlideModule.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/di/GlideModule.kt
@@ -9,21 +9,19 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy.RESOURCE
 import com.bumptech.glide.load.engine.cache.InternalCacheDiskCacheFactory
 import com.bumptech.glide.module.AppGlideModule
 import com.bumptech.glide.request.RequestOptions
+import dev.jdtech.jellyfin.utils.Constants
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-private const val cacheDefaultSize = 250
-
 @GlideModule
 class GlideModule : AppGlideModule() {
-
     override fun applyOptions(context: Context, builder: GlideBuilder) {
         val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val use = preferences.getBoolean("use_image_cache", false)
+        val use = preferences.getBoolean(Constants.PREF_IMAGE_CACHE, true)
 
         if (use) {
-            val sizeMb = preferences.getString("image_cache_size", "$cacheDefaultSize")?.toInt()!!
+            val sizeMb = preferences.getString(Constants.PREF_IMAGE_CACHE_SIZE, "${Constants.DEFAULT_CACHE_SIZE}")?.toInt()!!
             val sizeB = 1024L * 1024 * sizeMb
             Timber.d("Setting image cache to use $sizeMb MB of disk space")
 

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/AppPreferences.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/AppPreferences.kt
@@ -10,6 +10,11 @@ class AppPreferences
 constructor(
     private val sharedPreferences: SharedPreferences
 ) {
+    val playerGestures = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES, true)
+
+    val playerBrightnessRemember =
+        sharedPreferences.getBoolean(Constants.PREF_PLAYER_BRIGHTNESS_REMEMBER, false)
+
     var playerBrightness: Float
         get() = sharedPreferences.getFloat(
             Constants.PREF_PLAYER_BRIGHTNESS,
@@ -20,5 +25,4 @@ constructor(
                 putFloat(Constants.PREF_PLAYER_BRIGHTNESS, value)
             }
         }
-
 }

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
@@ -11,4 +11,9 @@ object Constants {
     const val PREF_PLAYER_GESTURES = "pref_player_gestures"
     const val PREF_PLAYER_BRIGHTNESS_REMEMBER = "pref_player_brightness_remember"
     const val PREF_PLAYER_BRIGHTNESS = "pref_player_brightness"
+    const val PREF_IMAGE_CACHE = "pref_image_cache"
+    const val PREF_IMAGE_CACHE_SIZE = "pref_image_cache_size"
+
+    // caching
+    const val DEFAULT_CACHE_SIZE = 20
 }

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
@@ -1,14 +1,14 @@
 package dev.jdtech.jellyfin.utils
 
 object Constants {
-
-    //player
+    // player
     const val GESTURE_EXCLUSION_AREA_TOP = 48
     const val FULL_SWIPE_RANGE_SCREEN_RATIO = 0.66f
     const val ZOOM_SCALE_BASE = 1f
     const val ZOOM_SCALE_THRESHOLD = 0.01f
 
-    //pref
+    // pref
+    const val PREF_PLAYER_GESTURES = "pref_player_gestures"
+    const val PREF_PLAYER_BRIGHTNESS_REMEMBER = "pref_player_brightness_remember"
     const val PREF_PLAYER_BRIGHTNESS = "pref_player_brightness"
-
 }

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -115,7 +115,9 @@ class PlayerGestureHelper(
 
     private val hideGestureBrightnessIndicatorOverlayAction = Runnable {
         activity.binding.gestureBrightnessLayout.visibility = View.GONE
-        appPreferences.playerBrightness = activity.window.attributes.screenBrightness
+        if (appPreferences.playerBrightnessRemember) {
+            appPreferences.playerBrightness = activity.window.attributes.screenBrightness
+        }
     }
 
     /**
@@ -141,7 +143,9 @@ class PlayerGestureHelper(
     }
 
     init {
-        activity.window.attributes.screenBrightness = appPreferences.playerBrightness
+        if (appPreferences.playerBrightnessRemember) {
+            activity.window.attributes.screenBrightness = appPreferences.playerBrightness
+        }
         @Suppress("ClickableViewAccessibility")
         playerView.setOnTouchListener { _, event ->
             if (playerView.useController) {

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -55,8 +55,8 @@
     <string name="unknown_error">Error desconocido</string>
 	<string name="search_hint">Buscar películas, series, episodios…</string>
     <string name="latest_library">Reciente en %1$s</string>
-    <string name="mpv_player">Reproductor MPV</string>
-    <string name="mpv_player_summary">Usar el reproductor MPV parar reproducir contenidos. MPV soporta mas codecs de video, audio y subtitulos.</string>
+    <string name="mpv_player">Reproductor mpv</string>
+    <string name="mpv_player_summary">Usar el reproductor mpv parar reproducir contenidos. mpv soporta mas codecs de video, audio y subtitulos.</string>
     <string name="select_audio_track">Elegir pista de audio</string>
     <string name="select_subtile_track">Elegir subtítulo</string>
     <string name="force_software_decoding">Forzar la decodificación por software</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -70,8 +70,8 @@
     <string name="unknown_error">Neočekávaná chyba</string>
     <string name="select_audio_track">Vyberte zvukovou stopu</string>
     <string name="select_subtile_track">Vyberte titulky</string>
-    <string name="mpv_player">MPV přehrávač</string>
-    <string name="mpv_player_summary">Použít experimentální MPV přehrávač k přehrávání videí. MPV má podporu pro více video a audio kodeků a formátů titulků.</string>
+    <string name="mpv_player">mpv přehrávač</string>
+    <string name="mpv_player_summary">Použít experimentální mpv přehrávač k přehrávání videí. mpv má podporu pro více video a audio kodeků a formátů titulků.</string>
     <string name="force_software_decoding">Vynutit softwarové dekódování</string>
     <string name="force_software_decoding_summary">Vypnout hardwarové dekódování a vynutit softwarové dekódování. Může být užitečné pokud hardwarové dekódování produkuje artefakty.</string>
     <string name="image_description_poster">%1$s plakát</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -55,8 +55,8 @@
     <string name="app_info">Información de la App</string>
     <string name="unknown_error">Error desconocido</string>
 	<string name="search_hint">Buscar películas, series, episodios…</string>
-    <string name="mpv_player">Reproductor MPV</string>
-    <string name="mpv_player_summary">Usar el reproductor MPV parar reproducir contenidos. MPV soporta mas codecs de video, audio y subtitulos.</string>
+    <string name="mpv_player">Reproductor mpv</string>
+    <string name="mpv_player_summary">Usar el reproductor mpv parar reproducir contenidos. mpv soporta mas codecs de video, audio y subtitulos.</string>
     <string name="select_subtile_track">Elegir subtítulo</string>
     <string name="select_audio_track">Elegir pista de audio</string>
     <string name="force_software_decoding">Forzar la decodificación por software</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,10 +55,10 @@
     <string name="app_info">Información de aplicación</string>
     <string name="unknown_error">Error desconocido</string>
 	<string name="search_hint">Buscar películas, series, episodios…</string>
-    <string name="mpv_player">Reproductor MPV</string>
+    <string name="mpv_player">Reproductor mpv</string>
     <string name="select_audio_track">Elegir pista de audio</string>
     <string name="select_subtile_track">Elegir pista de subtitulo</string>
-    <string name="mpv_player_summary">Usar el reproductor MPV parar reproducir contenidos. MPV soporta mas codecs de video, audio y subtitulos.</string>
+    <string name="mpv_player_summary">Usar el reproductor mpv parar reproducir contenidos. mpv soporta mas codecs de video, audio y subtitulos.</string>
     <string name="force_software_decoding">Forzar la decodificación por software</string>
     <string name="force_software_decoding_summary">Deshabilita la decodificación por hardtware y usa solo software. Puede ser útil sí la decodificación por hardware genera artefactos visuales.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,10 +80,10 @@
     <string name="select_audio_track">Select audio track</string>
     <string name="select_subtile_track">Select subtitle track</string>
     <string name="select_playback_speed">Select playback speed</string>
-    <string name="mpv_player">MPV Player</string>
+    <string name="mpv_player">mpv player</string>
     <string name="download_mobile_data">Download using mobile data</string>
     <string name="download_roaming">Download when roaming</string>
-    <string name="mpv_player_summary">Use the experimental MPV Player to play videos. MPV has support for more video, audio and subtitle codecs.</string>
+    <string name="mpv_player_summary">Use the experimental mpv player to play videos. mpv has support for more video, audio and subtitle codecs.</string>
     <string name="force_software_decoding">Force software decoding</string>
     <string name="force_software_decoding_summary">Disable hardware decoding and use software decoding. Can be useful if hardware decoding gives weird artifacts.</string>
     <string name="download_button_description">Download</string>
@@ -99,6 +99,10 @@
     <string name="share">Share</string>
     <string name="image_description_poster">%1$s poster</string>
     <string name="image_description_backdrop">%1$s backdrop</string>
+    <string name="gestures">Gestures</string>
+    <string name="player_gestures">Player gestures</string>
+    <string name="player_gestures_summary">Swipe up and down on the right side of the screen to change the volume and on the left side to change the brightness</string>
+    <string name="player_brightness_remember">Remember brightness level</string>
 
     <string-array name="sort_by_options">
         <item>Name</item>

--- a/app/src/main/res/xml/fragment_settings_cache.xml
+++ b/app/src/main/res/xml/fragment_settings_cache.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
     <SwitchPreference
-        app:key="use_image_cache"
+        app:defaultValue="true"
+        app:key="pref_image_cache"
         app:summary="@string/settings_use_cache_summary"
         app:title="@string/settings_use_cache_title" />
     <EditTextPreference
-        app:defaultValue="250"
-        app:dependency="use_image_cache"
+        app:defaultValue="20"
+        app:dependency="pref_image_cache"
         app:dialogMessage="@string/settings_cache_size_message"
-        app:key="image_cache_size"
+        app:key="pref_image_cache_size"
         app:title="@string/settings_cache_size"
         app:useSimpleSummaryProvider="true" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/fragment_settings_player.xml
+++ b/app/src/main/res/xml/fragment_settings_player.xml
@@ -1,16 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
     <SwitchPreference
-        app:key="mpv_player"
-        app:summary="@string/mpv_player_summary"
-        app:title="@string/mpv_player" />
-    <SwitchPreference
-        app:dependency="mpv_player"
-        app:key="mpv_disable_hwdec"
-        app:summary="@string/force_software_decoding_summary"
-        app:title="@string/force_software_decoding" />
-    <SwitchPreference
         app:key="display_extended_title"
         app:summary="@string/display_extended_title_summary"
         app:title="@string/display_extended_title" />
+
+    <PreferenceCategory app:title="@string/mpv_player">
+        <SwitchPreference
+            app:key="mpv_player"
+            app:summary="@string/mpv_player_summary"
+            app:title="@string/mpv_player" />
+        <SwitchPreference
+            app:dependency="mpv_player"
+            app:key="mpv_disable_hwdec"
+            app:summary="@string/force_software_decoding_summary"
+            app:title="@string/force_software_decoding" />
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/gestures">
+        <SwitchPreference
+            app:defaultValue="true"
+            app:key="pref_player_gestures"
+            app:summary="@string/player_gestures_summary"
+            app:title="@string/player_gestures" />
+        <SwitchPreference
+            app:dependency="pref_player_gestures"
+            app:key="pref_player_brightness_remember"
+            app:title="@string/player_brightness_remember" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Provide some more configurable options.

These include:
- Player gestures (true)
- Remember player brightness level (false)

Changes these defaults:
- Cache images: false -> true
- Cache size: 250 -> 20

Also includes a fix for ProGuard removing the SettingsFragments