### PR TITLE
Fix trailing slash in baseUrl not loading images

### DIFF
--- a/app/src/main/java/dev/jdtech/jellyfin/BindingAdapters.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/BindingAdapters.kt
@@ -106,7 +106,7 @@ fun bindSeasonPoster(imageView: ImageView, seasonId: UUID) {
 private fun ImageView.loadImage(url: String, @DrawableRes errorPlaceHolderId: Int? = null): View {
     val api = JellyfinApi.getInstance(context.applicationContext)
 
-    return Glide
+    Glide
         .with(context)
         .load("${api.api.baseUrl}$url")
         .transition(DrawableTransitionOptions.withCrossFade())
@@ -114,6 +114,8 @@ private fun ImageView.loadImage(url: String, @DrawableRes errorPlaceHolderId: In
         .error(errorPlaceHolderId)
         .into(this)
         .view
+
+    return this
 }
 
 private fun View.posterDescription(name: String?) {

--- a/app/src/main/java/dev/jdtech/jellyfin/fragments/AddServerFragment.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/fragments/AddServerFragment.kt
@@ -82,7 +82,7 @@ class AddServerFragment : Fragment() {
 
     private fun connectToServer() {
         val serverAddress = binding.editTextServerAddress.text.toString()
-        viewModel.checkServer(serverAddress)
+        viewModel.checkServer(serverAddress.removeSuffix("/"))
     }
 
     private fun navigateToLoginFragment() {


### PR DESCRIPTION
When the user added a server using a trailing slash `/` ex. `demo.jellyfin.org/stable/` all images fail to load.
A simple fix is to remove all trailing slashes when adding the server.
The only issue with this is that the users who added their server with a trailing slash will have to first remove and then add their server again.

An other solution could be to remove trailing slashes every time an image request is made, but this would not be ideal for performance.

Fix #113 