### PR TITLE
Split gesture option into volume & brightness and zoom

### DIFF
--- a/app/src/main/java/dev/jdtech/jellyfin/utils/AppPreferences.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/AppPreferences.kt
@@ -11,6 +11,8 @@ constructor(
     private val sharedPreferences: SharedPreferences
 ) {
     val playerGestures = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES, true)
+    val playerGesturesVB = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES_VB, true)
+    val playerGesturesZoom = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES_ZOOM, true)
 
     val playerBrightnessRemember =
         sharedPreferences.getBoolean(Constants.PREF_PLAYER_BRIGHTNESS_REMEMBER, false)

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
@@ -9,6 +9,8 @@ object Constants {
 
     // pref
     const val PREF_PLAYER_GESTURES = "pref_player_gestures"
+    const val PREF_PLAYER_GESTURES_VB = "pref_player_gestures_vb"
+    const val PREF_PLAYER_GESTURES_ZOOM = "pref_player_gestures_zoom"
     const val PREF_PLAYER_BRIGHTNESS_REMEMBER = "pref_player_brightness_remember"
     const val PREF_PLAYER_BRIGHTNESS = "pref_player_brightness"
     const val PREF_IMAGE_CACHE = "pref_image_cache"

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -122,5 +122,5 @@
     <string name="gestures">Gestos</string>
     <string name="player_brightness_remember">Recordar el nivel de brillo</string>
     <string name="player_gestures">Gestos del reproductor</string>
-    <string name="player_gestures_summary">Desliza hacia arriba y hacia abajo en el lado derecho de la pantalla para cambiar el volumen y en el lado izquierdo para cambiar el brillo</string>
+    <string name="player_gestures_vb_summary">Desliza hacia arriba y hacia abajo en el lado derecho de la pantalla para cambiar el volumen y en el lado izquierdo para cambiar el brillo</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -121,5 +121,5 @@
     <string name="display_extended_title_summary">Zeige erweiterten Episodentitel inklusiver der Staffel und Episodeninformationen (SXX:EXX - Episodenname).</string>
     <string name="app_description">Native Drittanbieter Jellyfin App</string>
     <string name="remove_server_dialog_text">Sicher, dass du den Server %1$s entfernen willst</string>
-    <string name="player_gestures_summary">Wische auf der rechten Seite des Bildschirms hoch und runter, um die Lautstärke anzupassen und auf der linken Seite, um gleiches mit der Helligkeit zu machen</string>
+    <string name="player_gestures_vb_summary">Wische auf der rechten Seite des Bildschirms hoch und runter, um die Lautstärke anzupassen und auf der linken Seite, um gleiches mit der Helligkeit zu machen</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -122,5 +122,5 @@
     <string name="player_gestures">Gestos del reproductor</string>
     <string name="player_brightness_remember">Recordar el nivel de brillo</string>
     <string name="gestures">Gestos</string>
-    <string name="player_gestures_summary">Desliza hacia arriba y hacia abajo en el lado derecho de la pantalla para cambiar el volumen y en el lado izquierdo para cambiar el brillo</string>
+    <string name="player_gestures_vb_summary">Desliza hacia arriba y hacia abajo en el lado derecho de la pantalla para cambiar el volumen y en el lado izquierdo para cambiar el brillo</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -122,5 +122,5 @@
     <string name="gestures">Gestos</string>
     <string name="player_gestures">Gestos del reproductor</string>
     <string name="player_brightness_remember">Recordar nivel de brillo</string>
-    <string name="player_gestures_summary">Deslice hacia arriba y hacia abajo en el lado derecho de la pantalla para cambiar el volumen y en el lado izquierdo para cambiar el brillo</string>
+    <string name="player_gestures_vb_summary">Deslice hacia arriba y hacia abajo en el lado derecho de la pantalla para cambiar el volumen y en el lado izquierdo para cambiar el brillo</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -107,7 +107,7 @@
     <string name="image_description_backdrop">Toile de fond %1$s</string>
     <string name="gestures">Gestes</string>
     <string name="player_gestures">Gestes du lecteur</string>
-    <string name="player_gestures_summary">Glissez vers le haut ou vers le bas sur le côté droit de l\'écran pour modifier le volume et sur le côté gauche de l\'écran pour modifier la luminosité</string>
+    <string name="player_gestures_vb_summary">Glissez vers le haut ou vers le bas sur le côté droit de l\'écran pour modifier le volume et sur le côté gauche de l\'écran pour modifier la luminosité</string>
     <string name="select_video_version_title">Choisissez une version</string>
     <string name="display_extended_title_summary">Afficher le titre étendu inclut la numérotation de la saison et de l\'épisode (SXX:EXX - NomEpisode).</string>
     <string name="add_server_empty_error">Adresse du serveur vide</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -7,7 +7,7 @@
     <string name="select_a_version">Wybierz wersję</string>
     <string name="download_mobile_data">Pobieraj używając danych komórkowych</string>
     <string name="mpv_player_summary">Używaj eksperymentalnego odtwarzacza MPV do odtwarzania wideo. MPV wspiera więcej kodeków wideo, audio i napisów.</string>
-    <string name="player_gestures_summary">Przesuń w górę lub w dół po prawej stronie ekrany by zmienić głośność, po lewej stronie by zmienić jasność</string>
+    <string name="player_gestures_vb_summary">Przesuń w górę lub w dół po prawej stronie ekrany by zmienić głośność, po lewej stronie by zmienić jasność</string>
     <string name="display_extended_title_summary">Wyświetlaj rozszerzoną nazwę odcinka, razem z informacją o sezonie i odcinku (SXX:EXX - NazwaOdcinka).</string>
     <string name="add_server_error_slow">Zbyt wolna odpowiedź serwera: %1$s</string>
     <string name="add_server_error_already_added">Serwer już dodany</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -107,7 +107,7 @@
     <string name="app_description">第三方原生Jellyfin app</string>
     <string name="login_error_wrong_username_password">用户名或密码错误</string>
     <string name="latest_library">最新%1$s</string>
-    <string name="player_gestures_summary">在屏幕右侧上下划动来调整音量，在屏幕左侧上下划动来调整亮度</string>
+    <string name="player_gestures_vb_summary">在屏幕右侧上下划动来调整音量，在屏幕左侧上下划动来调整亮度</string>
     <string name="add_server_error_outdated">服务器版本过旧：%1$s。请更新您的服务器</string>
     <string name="edit_text_server_address_hint">服务器地址</string>
     <string name="no_favorites">你没有收藏过任何东西</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,10 @@
     <string name="image_description_backdrop">%1$s backdrop</string>
     <string name="gestures">Gestures</string>
     <string name="player_gestures">Player gestures</string>
-    <string name="player_gestures_summary">Swipe up and down on the right side of the screen to change the volume and on the left side to change the brightness</string>
+    <string name="player_gestures_vb">Volume and brightness gestures</string>
+    <string name="player_gestures_zoom">Zoom gesture</string>
+    <string name="player_gestures_vb_summary">Swipe up and down on the right side of the screen to change the volume and on the left side to change the brightness</string>
+    <string name="player_gestures_zoom_summary">Pinch to fill the screen with the video</string>
     <string name="player_brightness_remember">Remember brightness level</string>
     <string name="sort_by_options_0">Name</string>
     <string name="sort_by_options_1">IMDB Rating</string>

--- a/app/src/main/res/xml/fragment_settings_player.xml
+++ b/app/src/main/res/xml/fragment_settings_player.xml
@@ -21,10 +21,21 @@
         <SwitchPreference
             app:defaultValue="true"
             app:key="pref_player_gestures"
-            app:summary="@string/player_gestures_summary"
             app:title="@string/player_gestures" />
         <SwitchPreference
+            app:defaultValue="true"
             app:dependency="pref_player_gestures"
+            app:key="pref_player_gestures_vb"
+            app:summary="@string/player_gestures_vb_summary"
+            app:title="@string/player_gestures_vb" />
+        <SwitchPreference
+            app:defaultValue="true"
+            app:dependency="pref_player_gestures"
+            app:key="pref_player_gestures_zoom"
+            app:summary="@string/player_gestures_zoom_summary"
+            app:title="@string/player_gestures_zoom" />
+        <SwitchPreference
+            app:dependency="pref_player_gestures_vb"
             app:key="pref_player_brightness_remember"
             app:title="@string/player_brightness_remember" />
     </PreferenceCategory>


### PR DESCRIPTION
Adds two more options to individually disable the following gestures:
- Volume and brightness
- Zoom

Before you could only disable all player gestures.

Closes #120 