### PR TITLE
Enable Material You Dynamic colors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     implementation("androidx.leanback:leanback:1.2.0-alpha02")
 
     implementation("androidx.core:core-ktx:1.8.0")
-    implementation("androidx.core:core-splashscreen:1.0.0")
     implementation("androidx.appcompat:appcompat:1.4.2")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.FindroidSplashScreen"
             android:windowSoftInputMode="adjustResize">
 
             <intent-filter>

--- a/app/src/main/java/dev/jdtech/jellyfin/BaseApplication.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/BaseApplication.kt
@@ -3,23 +3,28 @@ package dev.jdtech.jellyfin
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
+import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.HiltAndroidApp
+import dev.jdtech.jellyfin.utils.AppPreferences
 import timber.log.Timber
 
 @HiltAndroidApp
 class BaseApplication : Application() {
     override fun onCreate() {
-        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+        super.onCreate()
 
-        when (sharedPreferences.getString("theme", null)) {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+
+        val appPreferences = AppPreferences(PreferenceManager.getDefaultSharedPreferences(this))
+
+        when (appPreferences.theme) {
             "system" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
             "light" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
             "dark" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
         }
 
-        super.onCreate()
-        if (BuildConfig.DEBUG) {
-            Timber.plant(Timber.DebugTree())
-        }
+        if (appPreferences.dynamicColors) DynamicColors.applyToActivitiesIfAvailable(this)
     }
 }

--- a/app/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
@@ -3,7 +3,6 @@ package dev.jdtech.jellyfin
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
@@ -23,7 +22,6 @@ class MainActivity : AppCompatActivity() {
     lateinit var database: ServerDatabaseDao
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         binding = ActivityMainAppBinding.inflate(layoutInflater)

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/AppPreferences.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/AppPreferences.kt
@@ -12,6 +12,11 @@ class AppPreferences
 constructor(
     private val sharedPreferences: SharedPreferences
 ) {
+    // Appearance
+    val theme = sharedPreferences.getString(Constants.PREF_THEME, null)
+    val dynamicColors = sharedPreferences.getBoolean(Constants.PREF_DYNAMIC_COLORS, true)
+
+    // Player
     val playerGestures = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES, true)
     val playerGesturesVB = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES_VB, true)
     val playerGesturesZoom = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES_ZOOM, true)

--- a/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/utils/Constants.kt
@@ -17,6 +17,8 @@ object Constants {
     const val PREF_PLAYER_SEEK_FORWARD_INC = "pref_player_seek_forward_inc"
     const val PREF_IMAGE_CACHE = "pref_image_cache"
     const val PREF_IMAGE_CACHE_SIZE = "pref_image_cache_size"
+    const val PREF_THEME = "theme"
+    const val PREF_DYNAMIC_COLORS = "dynamic_colors"
 
     // caching
     const val DEFAULT_CACHE_SIZE = 20

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -16,10 +16,4 @@
         <item name="android:colorBackground">@color/neutral_1000</item>
         <item name="colorSurface">@color/neutral_900</item>
     </style>
-
-    <style name="Theme.FindroidSplashScreen" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
-        <item name="windowSplashScreenBackground">@color/black</item>
-        <item name="postSplashScreenTheme">@style/Theme.Findroid</item>
-    </style>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,4 +128,6 @@
     <string name="seeking">Seeking</string>
     <string name="seek_back_increment">Seek back increment (ms)</string>
     <string name="seek_forward_increment">Seek forward increment (ms)</string>
+    <string name="dynamic_colors">Dynamic colors</string>
+    <string name="dynamic_colors_summary">Use Material You Dynamic colors (only available on Android 12+)</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -39,12 +39,6 @@
         <item name="elevationOverlayEnabled">false</item>
     </style>
 
-    <style name="Theme.FindroidSplashScreen" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
-        <item name="windowSplashScreenBackground">@color/white</item>
-        <item name="postSplashScreenTheme">@style/Theme.Findroid</item>
-    </style>
-
     <string-array name="themes">
         <item>Follow system</item>
         <item>Light</item>

--- a/app/src/main/res/xml/fragment_settings_appearance.xml
+++ b/app/src/main/res/xml/fragment_settings_appearance.xml
@@ -7,4 +7,9 @@
         app:key="theme"
         app:title="@string/theme"
         app:useSimpleSummaryProvider="true" />
+    <SwitchPreference
+        app:defaultValue="true"
+        app:key="dynamic_colors"
+        app:summary="@string/dynamic_colors_summary"
+        app:title="@string/dynamic_colors" />
 </PreferenceScreen>


### PR DESCRIPTION
Enable Material You dynamic colors on all activities.
This also removes the `androidx.core.core-splashscreen` library because of an incompatibility between the splash screen and the dynamic colors.
A poll on Discord has decided that the dynamic colors are more important than the splash screen.

Note: Android 12+ has a built-in splash screen for all apps. Only Android <12 uses the splash screen library.

Closes #133 