### PR TITLE
Add subtitles settings button to player settings

### DIFF
--- a/app/src/main/java/dev/jdtech/jellyfin/fragments/SettingsPlayerFragment.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/fragments/SettingsPlayerFragment.kt
@@ -1,8 +1,11 @@
 package dev.jdtech.jellyfin.fragments
 
+import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import android.text.InputType
 import androidx.preference.EditTextPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import dev.jdtech.jellyfin.R
 
@@ -15,6 +18,10 @@ class SettingsPlayerFragment : PreferenceFragmentCompat() {
         }
         findPreference<EditTextPreference>("pref_player_seek_forward_inc")?.setOnBindEditTextListener { editText ->
             editText.inputType = InputType.TYPE_CLASS_NUMBER
+        }
+        findPreference<Preference>("pref_player_subtitles")?.setOnPreferenceClickListener {
+            startActivity(Intent(Settings.ACTION_CAPTIONING_SETTINGS))
+            true
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,6 @@
     <string name="seek_forward_increment">Seek forward increment (ms)</string>
     <string name="dynamic_colors">Dynamic colors</string>
     <string name="dynamic_colors_summary">Use Material You Dynamic colors (only available on Android 12+)</string>
+    <string name="subtitles">Subtitles</string>
+    <string name="subtitles_summary">Customize subtitles appearance</string>
 </resources>

--- a/app/src/main/res/xml/fragment_settings_player.xml
+++ b/app/src/main/res/xml/fragment_settings_player.xml
@@ -5,6 +5,11 @@
         app:summary="@string/display_extended_title_summary"
         app:title="@string/display_extended_title" />
 
+    <Preference
+        app:key="pref_player_subtitles"
+        app:title="@string/subtitles"
+        app:summary="@string/subtitles_summary"/>
+
     <PreferenceCategory app:title="@string/mpv_player">
         <SwitchPreference
             app:key="mpv_player"


### PR DESCRIPTION
Add a subtitles button in the settings which navigates to the Android system caption settings.
This is where the appearance of the subtitles can be changed.

Closes #151 