### PR TITLE
[TV] Set correct navigation start destination

### DIFF
--- a/app/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
@@ -47,15 +47,25 @@ class MainActivity : AppCompatActivity() {
 
         if (uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
             graph.setStartDestination(R.id.homeFragmentTv)
-            navController.setGraph(graph, intent.extras)
-        }
-
-        val nServers = database.getServersCount()
-        if (nServers < 1) {
-            if (!viewModel.startDestinationChanged) {
-                graph.setStartDestination(R.id.addServerFragment)
+            val nServers = database.getServersCount()
+            if (nServers < 1) {
+                if (!viewModel.startDestinationChanged) {
+                    graph.setStartDestination(R.id.addServerFragment)
+                    viewModel.startDestinationChanged = true
+                }
+            }
+            if (!viewModel.startDestinationTvChanged) {
+                viewModel.startDestinationTvChanged = true
                 navController.setGraph(graph, intent.extras)
-                viewModel.startDestinationChanged = true
+            }
+        } else {
+            val nServers = database.getServersCount()
+            if (nServers < 1) {
+                if (!viewModel.startDestinationChanged) {
+                    graph.setStartDestination(R.id.addServerFragment)
+                    navController.setGraph(graph, intent.extras)
+                    viewModel.startDestinationChanged = true
+                }
             }
         }
 

--- a/app/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
@@ -4,4 +4,5 @@ import androidx.lifecycle.ViewModel
 
 class MainViewModel : ViewModel() {
     var startDestinationChanged = false
+    var startDestinationTvChanged = false
 }


### PR DESCRIPTION
When loading the app on TV for the first time the startDestination is not changed to the addServerFragment.
This fixes that.

Fix #159