### PR TITLE
Use version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,12 +1,13 @@
+@Suppress("DSL_SCOPE_VIOLATION") // False positive
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
-    id("kotlin-parcelize")
-    id("kotlin-kapt")
-    id("androidx.navigation.safeargs.kotlin")
-    id("dagger.hilt.android.plugin")
-    id("com.mikepenz.aboutlibraries.plugin")
-    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.androidx.navigation.safeargs)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.aboutlibraries)
+    alias(libs.plugins.ktlint)
 }
 
 android {
@@ -67,74 +68,38 @@ ktlint {
 }
 
 dependencies {
-    implementation("androidx.leanback:leanback:1.2.0-alpha02")
+    implementation(libs.aboutlibraries.core)
+    implementation(libs.aboutlibraries)
+    implementation(libs.androidx.activity)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.leanback)
+    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.viewmodel)
+    implementation(libs.androidx.navigation.fragment)
+    implementation(libs.androidx.navigation.ui)
+    implementation(libs.androidx.paging)
+    implementation(libs.androidx.preference)
+    implementation(libs.androidx.recyclerview)
+    implementation(libs.androidx.recyclerview.selection)
+    implementation(libs.androidx.room.runtime)
+    kapt(libs.androidx.room.compiler)
+    implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.swiperefreshlayout)
+    implementation(libs.exoplayer.core)
+    implementation(libs.exoplayer.ui)
+    implementation(libs.glide)
+    kapt(libs.glide.compiler)
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.compiler)
+    implementation(libs.jellyfin.core)
+    implementation(libs.material)
+    implementation(libs.timber)
 
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.5.1")
-    implementation("androidx.activity:activity-ktx:1.6.1")
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-
-    // Material
-    implementation("com.google.android.material:material:1.7.0")
-
-    // ConstraintLayout
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-
-    // Lifecycle
-    val lifecycleVersion = "2.5.1"
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
-
-    // Navigation
-    val navigationVersion = "2.5.3"
-    implementation("androidx.navigation:navigation-fragment-ktx:$navigationVersion")
-    implementation("androidx.navigation:navigation-ui-ktx:$navigationVersion")
-
-    // RecyclerView
-    implementation("androidx.recyclerview:recyclerview:1.2.1")
-    implementation("androidx.recyclerview:recyclerview-selection:1.1.0")
-
-    // Room
-    val roomVersion = "2.4.3"
-    implementation("androidx.room:room-runtime:$roomVersion")
-    kapt("androidx.room:room-compiler:$roomVersion")
-    implementation("androidx.room:room-ktx:$roomVersion")
-
-    // Preference
-    val preferenceVersion = "1.2.0"
-    implementation("androidx.preference:preference-ktx:$preferenceVersion")
-
-    // Jellyfin
-    val jellyfinVersion = "1.3.7"
-    implementation("org.jellyfin.sdk:jellyfin-core:$jellyfinVersion")
-
-    // Glide
-    val glideVersion = "4.14.2"
-    implementation("com.github.bumptech.glide:glide:$glideVersion")
-    kapt("com.github.bumptech.glide:compiler:$glideVersion")
-
-    // Hilt
-    val hiltVersion = "2.44"
-    implementation("com.google.dagger:hilt-android:$hiltVersion")
-    kapt("com.google.dagger:hilt-compiler:$hiltVersion")
-
-    // ExoPlayer
-    val exoplayerVersion = "2.18.1"
-    implementation("com.google.android.exoplayer:exoplayer-core:$exoplayerVersion")
-    implementation("com.google.android.exoplayer:exoplayer-ui:$exoplayerVersion")
+    // ExoPlayer FFmpeg extension
     implementation(files("libs/extension-ffmpeg-release.aar"))
 
     // MPV
     implementation(files("libs/libmpv.aar"))
-
-    // Timber
-    val timberVersion = "5.0.1"
-    implementation("com.jakewharton.timber:timber:$timberVersion")
-
-    val aboutLibrariesVersion = "10.5.1"
-    implementation("com.mikepenz:aboutlibraries-core:$aboutLibrariesVersion")
-    implementation("com.mikepenz:aboutlibraries:$aboutLibrariesVersion")
-
-    val pagingVersion = "3.1.1"
-    implementation("androidx.paging:paging-runtime-ktx:$pagingVersion")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,29 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
-        }
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:7.3.1")
-
-        val kotlinVersion = "1.7.20"
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle.kts files
-        val navVersion = "2.5.3"
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$navVersion")
-
-        val hiltVersion = "2.44"
-        classpath("com.google.dagger:hilt-android-gradle-plugin:$hiltVersion")
-
-        val aboutLibrariesVersion = "10.5.1"
-        classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:$aboutLibrariesVersion")
-    }
+@Suppress("DSL_SCOPE_VIOLATION") // False positive
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.androidx.navigation.safeargs) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.aboutlibraries) apply false
+    alias(libs.plugins.ktlint) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,64 @@
+[versions]
+aboutlibraries = "10.5.1"
+android-plugin = "7.3.1"
+androidx-activity = "1.6.1"
+androidx-appcompat = "1.5.1"
+androidx-constraintlayout = "2.1.4"
+androidx-core = "1.9.0"
+androidx-leanback = "1.2.0-alpha02"
+androidx-lifecycle = "2.5.1"
+androidx-navigation = "2.5.3"
+androidx-paging = "3.1.1"
+androidx-preference = "1.2.0"
+androidx-recyclerview = "1.2.1"
+androidx-recyclerview-selection = "1.1.0"
+androidx-room = "2.4.3"
+androidx-swiperefreshlayout = "1.1.0"
+exoplayer = "2.18.1"
+glide = "4.14.2"
+hilt = "2.44"
+jellyfin = "1.3.7"
+kotlin = "1.7.20"
+ktlint = "11.0.0"
+material = "1.7.0"
+timber = "5.0.1"
+
+[libraries]
+aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
+aboutlibraries = { module = "com.mikepenz:aboutlibraries", version.ref = "aboutlibraries" }
+androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-leanback = { module = "androidx.leanback:leanback", version.ref = "androidx-leanback" }
+androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
+androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
+androidx-paging = { module = "androidx.paging:paging-runtime-ktx", version.ref = "androidx-paging" }
+androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
+androidx-recyclerview-selection = { module = "androidx.recyclerview:recyclerview-selection", version.ref = "androidx-recyclerview-selection" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
+androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "androidx-swiperefreshlayout" }
+exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
+exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.ref = "exoplayer" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+jellyfin-core = { module = "org.jellyfin.sdk:jellyfin-core", version.ref = "jellyfin" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+
+[plugins]
+aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
+android-application = { id = "com.android.application", version.ref = "android-plugin" }
+androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,9 @@
 include(":app")
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}


### PR DESCRIPTION
Use a version catalog to centralize all project dependencies and versions.

This will make it easy for a bot like renovate to upgrade the dependencies.
And also helps when we start splitting this project into modules.