### PR TITLE
[fix] activity_main was a symlink, converted to xml file

### DIFF
--- a/app/src/main/res/layout-w600dp-television/activity_main.xml
+++ b/app/src/main/res/layout-w600dp-television/activity_main.xml
@@ -1,1 +1,19 @@
-../layout-television/activity_main.xml
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment_activity_main"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="parent"
+        app:navGraph="@navigation/app_navigation" />
+
+</FrameLayout>


### PR DESCRIPTION
The activity_main.xml at "app/src/main/res/layout-w600dp-television/activity_main.xml" was a symlink to "app/src/main/res/layout-television/activity_main.xml" causing the build to fail. To resolve this, copied the activity_main.xml from layout-television to layout-w600db-television.