### PR TITLE
Fix downloads when intro skipper is enabled and server is not reachable

### DIFF
--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
@@ -227,7 +227,6 @@ class JellyfinRepositoryImpl(private val jellyfinApi: JellyfinApi) : JellyfinRep
             try {
                 return@withContext jellyfinApi.api.get<Intro>("/Episode/{itemId}/IntroTimestamps/v1", pathParameters).content
             } catch (e: InvalidStatusException) {
-                if (e.status != 404) throw e
                 return@withContext null
             }
         }


### PR DESCRIPTION
The `getIntroTimestamps` function would throw an error if any error other than a 404 occured. This isn't a problem when playing from the server, because it must be available to stream the video at all. However, when playing from downloads, the server doesn't need to be available, and the function throws an error. I fixed this by making the function never throw an error.