### PR TITLE
Fix mpv player crashing on exiting the player when the item has finished playing

### DIFF
--- a/player/video/src/main/java/dev/jdtech/jellyfin/mpv/MPVPlayer.kt
+++ b/player/video/src/main/java/dev/jdtech/jellyfin/mpv/MPVPlayer.kt
@@ -209,7 +209,7 @@ class MPVPlayer(
             when (property) {
                 "eof-reached" -> {
                     if (value && isPlayerReady) {
-                        if (currentIndex < (internalMediaItems.size)) {
+                        if (currentIndex < (internalMediaItems.size - 1)) {
                             currentIndex += 1
                             prepareMediaItem(currentIndex)
                             play()


### PR DESCRIPTION
When exiting the player when the file has ended the player would crash if using mpv player.
This was due to a pretty stupid mistake in the eof check in MpvPlayer

This also makes sure the player closes when it finishes playing the last item.