### PR TITLE
Fix downloads with introskipper enabled (again)

### DIFF
--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
@@ -229,7 +229,7 @@ class JellyfinRepositoryImpl(private val jellyfinApi: JellyfinApi) : JellyfinRep
 
             try {
                 return@withContext jellyfinApi.api.get<Intro>("/Episode/{itemId}/IntroTimestamps/v1", pathParameters).content
-            } catch (e: InvalidStatusException) {
+            } catch (e: Exception) {
                 return@withContext null
             }
         }


### PR DESCRIPTION
Turns out that the exception thrown when internet is completely disabled isn't an `InvalidStatusException`, so I just made it catch every exception. Fixes #261