### PR TITLE
Added a preferred stream quality option

### DIFF
--- a/core/src/main/res/values/string_arrays.xml
+++ b/core/src/main/res/values/string_arrays.xml
@@ -37,4 +37,20 @@
     <string-array name="mpv_gpu_api">
         <item>opengl</item>
     </string-array>
+    <string-array name="video_quality">
+        <item>Original</item>
+        <item>4K</item>
+        <item>1080p</item>
+        <item>720p</item>
+        <item>480p</item>
+        <item>360p</item>
+    </string-array>
+    <string-array name="video_quality_labels">
+        <item>@string/quality_original</item>
+        <item>4K</item>
+        <item>1080p</item>
+        <item>720p</item>
+        <item>480p</item>
+        <item>360p</item>
+    </string-array>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -151,4 +151,7 @@
     <string name="add_server_address">Add server address</string>
     <string name="add">Add</string>
     <string name="quick_connect">Quick Connect</string>
+    <string name="quality">Quality</string>
+    <string name="preferred_quality">%s\nAny setting other than Original might require transcoding.</string>
+    <string name="quality_original">Original</string>
 </resources>

--- a/core/src/main/res/xml/fragment_settings_player.xml
+++ b/core/src/main/res/xml/fragment_settings_player.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+    <DropDownPreference
+        app:defaultValue="Original"
+        app:entries="@array/video_quality_labels"
+        app:entryValues="@array/video_quality"
+        app:key="pref_player_preferred_quality"
+        app:summary="@string/preferred_quality"
+        app:title="@string/quality" />
+
     <SwitchPreference
         app:key="pref_player_display_extended_title"
         app:summary="@string/display_extended_title_summary"

--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepository.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepository.kt
@@ -63,6 +63,8 @@ interface JellyfinRepository {
 
     suspend fun getStreamUrl(itemId: UUID, mediaSourceId: String): String
 
+    suspend fun getHlsPlaylistUrl(itemId: UUID, mediaSourceId: String, transcodeResolution: Int?): String
+
     suspend fun getIntroTimestamps(itemId: UUID): Intro?
 
     suspend fun postCapabilities()

--- a/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerActivityViewModel.kt
+++ b/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerActivityViewModel.kt
@@ -105,6 +105,18 @@ constructor(
         }
     }
 
+    private fun getTranscodeResolution(preferredQuality: String): Int? {
+        return when (preferredQuality) {
+            "4K" -> 2160
+            "1080p" -> 1080
+            "720p" -> 720
+            "480p" -> 480
+            "360p" -> 360
+
+            else -> null
+        }
+    }
+
     fun initializePlayer(
         items: Array<PlayerItem>
     ) {
@@ -115,9 +127,13 @@ constructor(
             val mediaItems: MutableList<MediaItem> = mutableListOf()
             try {
                 for (item in items) {
+                    val transcodeResolution = getTranscodeResolution(appPreferences.playerPreferredQuality)
                     val streamUrl = when {
                         item.mediaSourceUri.isNotEmpty() -> item.mediaSourceUri
-                        else -> jellyfinRepository.getStreamUrl(item.itemId, item.mediaSourceId)
+                        else -> when (transcodeResolution) {
+                            null -> jellyfinRepository.getStreamUrl(item.itemId, item.mediaSourceId)
+                            else -> jellyfinRepository.getHlsPlaylistUrl(item.itemId, item.mediaSourceId, transcodeResolution)
+                        }
                     }
                     val mediaSubtitles = item.externalSubtitles.map { externalSubtitle ->
                         MediaItem.SubtitleConfiguration.Builder(externalSubtitle.uri)

--- a/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerViewModel.kt
+++ b/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MimeTypes
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.jdtech.jellyfin.AppPreferences
 import dev.jdtech.jellyfin.player.video.R
 import dev.jdtech.jellyfin.database.DownloadDatabaseDao
 import dev.jdtech.jellyfin.models.ExternalSubtitle
@@ -30,7 +31,8 @@ import timber.log.Timber
 class PlayerViewModel @Inject internal constructor(
     private val application: Application,
     private val repository: JellyfinRepository,
-    private val downloadDatabase: DownloadDatabaseDao
+    private val downloadDatabase: DownloadDatabaseDao,
+    private val appPreferences: AppPreferences
 ) : ViewModel() {
 
     private val playerItems = MutableSharedFlow<PlayerItemState>(
@@ -177,7 +179,8 @@ class PlayerViewModel @Inject internal constructor(
         val mediaSource = repository.getMediaSources(id)[mediaSourceIndex]
         val externalSubtitles = mutableListOf<ExternalSubtitle>()
         for (mediaStream in mediaSource.mediaStreams!!) {
-            if (mediaStream.isExternal && mediaStream.type == MediaStreamType.SUBTITLE && !mediaStream.deliveryUrl.isNullOrBlank()) {
+            if ((appPreferences.playerPreferredQuality != "Original" || mediaStream.isExternal) // When transcoding, subtitles aren't embedded, so we add them externally
+                && mediaStream.type == MediaStreamType.SUBTITLE && !mediaStream.deliveryUrl.isNullOrBlank()) {
 
                 // Temp fix for vtt
                 // Jellyfin returns a srt stream when it should return vtt stream.

--- a/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
@@ -26,6 +26,11 @@ constructor(
     val dynamicColors get() = sharedPreferences.getBoolean(Constants.PREF_DYNAMIC_COLORS, true)
 
     // Player
+    val playerPreferredQuality: String get() = sharedPreferences.getString(
+        Constants.PREF_PLAYER_PREFERRED_QUALITY,
+        "Original"
+    )!!
+
     val displayExtendedTitle get() = sharedPreferences.getBoolean(Constants.PREF_DISPLAY_EXTENDED_TITLE, false)
 
     val playerGestures get() = sharedPreferences.getBoolean(Constants.PREF_PLAYER_GESTURES, true)

--- a/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
@@ -9,6 +9,7 @@ object Constants {
 
     // pref
     const val PREF_CURRENT_SERVER = "pref_current_server"
+    const val PREF_PLAYER_PREFERRED_QUALITY = "pref_player_preferred_quality"
     const val PREF_DISPLAY_EXTENDED_TITLE = "pref_player_display_extended_title"
     const val PREF_PLAYER_GESTURES = "pref_player_gestures"
     const val PREF_PLAYER_GESTURES_VB = "pref_player_gestures_vb"


### PR DESCRIPTION
Added the option to select a preferred stream quality in the player settings. This works for both ExoPlayer and mpv.
You can either request the original file, or ask for a specific resolution (4K, 1080p, 720p, 480p, 360p).
If the asked resolution is lower than the original file's, it will require transcoding.

Ideally, the option to switch the quality should have been directly inside the player, however, I haven't found an easy way to set different stream URLs for different resolutions.

Please note that this option is only for video streaming, downloads still use the original file regardless.