### PR TITLE
feat(ui): make preference dialogs and switches material3-esque

### DIFF
--- a/core/src/main/res/layout/preference_material3_switch.xml
+++ b/core/src/main/res/layout/preference_material3_switch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.materialswitch.MaterialSwitch xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@null"
+    android:clickable="false"
+    android:focusable="false" />

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -40,6 +40,8 @@
 
         <!-- Extra -->
         <item name="elevationOverlayEnabled">false</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
+        <item name="dialogCornerRadius">28dp</item>
     </style>
 
     <string-array name="themes">

--- a/core/src/main/res/xml/fragment_settings_appearance.xml
+++ b/core/src/main/res/xml/fragment_settings_appearance.xml
@@ -7,9 +7,10 @@
         app:key="theme"
         app:title="@string/theme"
         app:useSimpleSummaryProvider="true" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         app:defaultValue="true"
         app:key="dynamic_colors"
         app:summary="@string/dynamic_colors_summary"
-        app:title="@string/dynamic_colors" />
+        app:title="@string/dynamic_colors"
+        app:widgetLayout="@layout/preference_material3_switch" />
 </PreferenceScreen>

--- a/core/src/main/res/xml/fragment_settings_cache.xml
+++ b/core/src/main/res/xml/fragment_settings_cache.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
-    <SwitchPreference
+    <SwitchPreferenceCompat
         app:defaultValue="true"
         app:key="pref_image_cache"
         app:summary="@string/settings_use_cache_summary"
-        app:title="@string/settings_use_cache_title" />
+        app:title="@string/settings_use_cache_title"
+        app:widgetLayout="@layout/preference_material3_switch" />
     <EditTextPreference
         app:defaultValue="20"
         app:dependency="pref_image_cache"

--- a/core/src/main/res/xml/fragment_settings_downloads.xml
+++ b/core/src/main/res/xml/fragment_settings_downloads.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <SwitchPreference
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
         app:key="download_mobile_data"
         app:title="@string/download_mobile_data"
-        android:defaultValue="false" />
-    <SwitchPreference
+        app:widgetLayout="@layout/preference_material3_switch" />
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
         app:key="download_roaming"
         app:title="@string/download_roaming"
-        android:defaultValue="false" />
+        app:widgetLayout="@layout/preference_material3_switch" />
 </PreferenceScreen>

--- a/core/src/main/res/xml/fragment_settings_player.xml
+++ b/core/src/main/res/xml/fragment_settings_player.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
-    <SwitchPreference
+    <SwitchPreferenceCompat
         app:key="pref_player_display_extended_title"
         app:summary="@string/display_extended_title_summary"
-        app:title="@string/display_extended_title" />
+        app:title="@string/display_extended_title"
+        app:widgetLayout="@layout/preference_material3_switch" />
 
     <Preference
         app:key="pref_player_subtitles"
@@ -11,11 +12,12 @@
         app:title="@string/subtitles" />
 
     <PreferenceCategory app:title="@string/mpv_player">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             app:key="pref_player_mpv"
             app:summary="@string/mpv_player_summary"
-            app:title="@string/mpv_player" />
-        <DropDownPreference
+            app:title="@string/mpv_player"
+            app:widgetLayout="@layout/preference_material3_switch" />
+        <ListPreference
             app:defaultValue="mediacodec-copy"
             app:dependency="pref_player_mpv"
             app:entries="@array/mpv_hwdec"
@@ -30,7 +32,7 @@
             app:entryValues="@array/mpv_hwdec_codecs"
             app:key="pref_player_mpv_hwdec_codecs"
             app:title="@string/pref_player_mpv_hwdec_codecs" />
-        <DropDownPreference
+        <ListPreference
             app:defaultValue="gpu"
             app:dependency="pref_player_mpv"
             app:entries="@array/mpv_vos"
@@ -38,7 +40,7 @@
             app:key="pref_player_mpv_vo"
             app:title="@string/pref_player_mpv_vo"
             app:useSimpleSummaryProvider="true" />
-        <DropDownPreference
+        <ListPreference
             app:defaultValue="audiotrack"
             app:dependency="pref_player_mpv"
             app:entries="@array/mpv_aos"
@@ -46,7 +48,7 @@
             app:key="pref_player_mpv_ao"
             app:title="@string/pref_player_mpv_ao"
             app:useSimpleSummaryProvider="true" />
-        <DropDownPreference
+        <ListPreference
             app:defaultValue="opengl"
             app:dependency="pref_player_mpv"
             app:entries="@array/mpv_gpu_api"
@@ -57,26 +59,30 @@
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/gestures">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             app:defaultValue="true"
             app:key="pref_player_gestures"
-            app:title="@string/player_gestures" />
-        <SwitchPreference
+            app:title="@string/player_gestures"
+            app:widgetLayout="@layout/preference_material3_switch" />
+        <SwitchPreferenceCompat
             app:defaultValue="true"
             app:dependency="pref_player_gestures"
             app:key="pref_player_gestures_vb"
             app:summary="@string/player_gestures_vb_summary"
-            app:title="@string/player_gestures_vb" />
-        <SwitchPreference
+            app:title="@string/player_gestures_vb"
+            app:widgetLayout="@layout/preference_material3_switch" />
+        <SwitchPreferenceCompat
             app:defaultValue="true"
             app:dependency="pref_player_gestures"
             app:key="pref_player_gestures_zoom"
             app:summary="@string/player_gestures_zoom_summary"
-            app:title="@string/player_gestures_zoom" />
-        <SwitchPreference
+            app:title="@string/player_gestures_zoom"
+            app:widgetLayout="@layout/preference_material3_switch" />
+        <SwitchPreferenceCompat
             app:dependency="pref_player_gestures_vb"
             app:key="pref_player_brightness_remember"
-            app:title="@string/player_brightness_remember" />
+            app:title="@string/player_brightness_remember"
+            app:widgetLayout="@layout/preference_material3_switch" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/seeking">
@@ -92,10 +98,11 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
-    <SwitchPreference
+    <SwitchPreferenceCompat
         app:defaultValue="true"
         app:key="pref_player_intro_skipper"
+        app:summary="@string/pref_player_intro_skipper_summary"
         app:title="@string/pref_player_intro_skipper"
-        app:summary="@string/pref_player_intro_skipper_summary"/>
+        app:widgetLayout="@layout/preference_material3_switch" />
 
 </PreferenceScreen>


### PR DESCRIPTION
Since the app is built around Material3, we can use overlays as of now for `androidx.preferences`. Also, the `ListPreference` looks much cleaner and modern for selections with Material3.

<img width="45%" src="https://user-images.githubusercontent.com/33605526/216692974-f2ea5f71-d0d0-4da6-aced-7023eafffbd2.png">		<img width="45%" src="https://user-images.githubusercontent.com/33605526/216692981-501c2373-3a52-4fb5-b8b4-1adb40958976.png">

<img width="45%" src="https://user-images.githubusercontent.com/33605526/216692984-9a224330-4b9c-46cb-9293-bf5d5ade83c1.png">		<img width="45%" src="https://user-images.githubusercontent.com/33605526/216692986-1b23f108-bd2e-486f-98e6-bf11d042ff9d.png">

<img width="45%" src="https://user-images.githubusercontent.com/33605526/216692990-6b9ce04e-3c37-4eff-8a2e-51969d0cfdf1.png">		<img width="45%" src="https://user-images.githubusercontent.com/33605526/216692992-8ca23d61-875e-4e39-8115-459ca617a155.png">

