### PR TITLE
refactor(ui): use a global preference style for Material3 switch

### DIFF
--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -9,4 +9,13 @@
         <item name="android:fontFamily">monospace</item>
     </style>
 
+    <!-- Preferences theme overlay to use new switch style, taken from Material Components Catalog example. -->
+    <style name="ThemeOverlay.Findroid.Preference" parent="PreferenceThemeOverlay">
+        <item name="switchPreferenceCompatStyle">@style/Preference.SwitchPreferenceCompat.Catalog</item>
+    </style>
+
+    <style name="Preference.SwitchPreferenceCompat.Catalog" parent="Preference.SwitchPreferenceCompat.Material">
+        <item name="android:widgetLayout">@layout/preference_material3_switch</item>
+    </style>
+
 </resources>

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -28,7 +28,9 @@
         <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
 
         <!-- Shapes -->
-        <item name="shapeAppearanceCornerExtraSmall">@style/ShapeAppearance.Findroid.Corner.ExtraSmall</item>
+        <item name="shapeAppearanceCornerExtraSmall">
+            @style/ShapeAppearance.Findroid.Corner.ExtraSmall
+        </item>
         <item name="shapeAppearanceCornerSmall">@style/ShapeAppearance.Findroid.Corner.Small</item>
 
         <!-- Toolbar -->
@@ -42,6 +44,7 @@
         <item name="elevationOverlayEnabled">false</item>
         <item name="alertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
         <item name="dialogCornerRadius">28dp</item>
+        <item name="preferenceTheme">@style/ThemeOverlay.Findroid.Preference</item>
     </style>
 
     <string-array name="themes">

--- a/core/src/main/res/xml/fragment_settings_appearance.xml
+++ b/core/src/main/res/xml/fragment_settings_appearance.xml
@@ -11,6 +11,5 @@
         app:defaultValue="true"
         app:key="dynamic_colors"
         app:summary="@string/dynamic_colors_summary"
-        app:title="@string/dynamic_colors"
-        app:widgetLayout="@layout/preference_material3_switch" />
+        app:title="@string/dynamic_colors" />
 </PreferenceScreen>

--- a/core/src/main/res/xml/fragment_settings_cache.xml
+++ b/core/src/main/res/xml/fragment_settings_cache.xml
@@ -4,8 +4,7 @@
         app:defaultValue="true"
         app:key="pref_image_cache"
         app:summary="@string/settings_use_cache_summary"
-        app:title="@string/settings_use_cache_title"
-        app:widgetLayout="@layout/preference_material3_switch" />
+        app:title="@string/settings_use_cache_title" />
     <EditTextPreference
         app:defaultValue="20"
         app:dependency="pref_image_cache"

--- a/core/src/main/res/xml/fragment_settings_downloads.xml
+++ b/core/src/main/res/xml/fragment_settings_downloads.xml
@@ -4,11 +4,9 @@
     <SwitchPreferenceCompat
         android:defaultValue="false"
         app:key="download_mobile_data"
-        app:title="@string/download_mobile_data"
-        app:widgetLayout="@layout/preference_material3_switch" />
+        app:title="@string/download_mobile_data" />
     <SwitchPreferenceCompat
         android:defaultValue="false"
         app:key="download_roaming"
-        app:title="@string/download_roaming"
-        app:widgetLayout="@layout/preference_material3_switch" />
+        app:title="@string/download_roaming" />
 </PreferenceScreen>

--- a/core/src/main/res/xml/fragment_settings_player.xml
+++ b/core/src/main/res/xml/fragment_settings_player.xml
@@ -15,8 +15,7 @@
         <SwitchPreferenceCompat
             app:key="pref_player_mpv"
             app:summary="@string/mpv_player_summary"
-            app:title="@string/mpv_player"
-            app:widgetLayout="@layout/preference_material3_switch" />
+            app:title="@string/mpv_player" />
         <ListPreference
             app:defaultValue="mediacodec-copy"
             app:dependency="pref_player_mpv"
@@ -62,34 +61,29 @@
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:key="pref_player_gestures"
-            app:title="@string/player_gestures"
-            app:widgetLayout="@layout/preference_material3_switch" />
+            app:title="@string/player_gestures" />
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:dependency="pref_player_gestures"
             app:key="pref_player_gestures_vb"
             app:summary="@string/player_gestures_vb_summary"
-            app:title="@string/player_gestures_vb"
-            app:widgetLayout="@layout/preference_material3_switch" />
+            app:title="@string/player_gestures_vb" />
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:dependency="pref_player_gestures"
             app:key="pref_player_gestures_zoom"
             app:summary="@string/player_gestures_zoom_summary"
-            app:title="@string/player_gestures_zoom"
-            app:widgetLayout="@layout/preference_material3_switch" />
+            app:title="@string/player_gestures_zoom" />
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:dependency="pref_player_gestures"
             app:key="pref_player_gestures_seek"
             app:summary="@string/player_gestures_seek_summary"
-            app:title="@string/player_gestures_seek"
-            app:widgetLayout="@layout/preference_material3_switch" />
+            app:title="@string/player_gestures_seek" />
         <SwitchPreferenceCompat
             app:dependency="pref_player_gestures_vb"
             app:key="pref_player_brightness_remember"
-            app:title="@string/player_brightness_remember"
-            app:widgetLayout="@layout/preference_material3_switch" />
+            app:title="@string/player_brightness_remember" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/seeking">


### PR DESCRIPTION
Optimising #268 even more, we can define a custom style for the preference so that we don't have to add `widgetLayout` everytime!