### PR TITLE
fix(mpv): memory leak, stuck loading icon, anr, deprecated methods

### DIFF
--- a/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerActivityViewModel.kt
+++ b/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerActivityViewModel.kt
@@ -24,9 +24,10 @@ import dev.jdtech.jellyfin.mpv.MPVPlayer
 import dev.jdtech.jellyfin.mpv.TrackType
 import dev.jdtech.jellyfin.repository.JellyfinRepository
 import dev.jdtech.jellyfin.utils.postDownloadPlaybackProgress
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.UUID
@@ -163,9 +164,10 @@ constructor(
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     private fun releasePlayer() {
         player.let { player ->
-            runBlocking {
+            GlobalScope.launch {
                 try {
                     jellyfinRepository.postPlaybackStop(
                         UUID.fromString(player.currentMediaItem?.mediaId),


### PR DESCRIPTION
- Fix the stuck loading icon when using mpv
- Remove observers when quitting
- Replace deprecated audio focus methods
- Fix ANR when leaving player

Fix #271 