### PR TITLE
Download handled is it exist in DB but not in file-storage

### DIFF
--- a/player/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadUtilities.kt
+++ b/player/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadUtilities.kt
@@ -122,7 +122,10 @@ fun canRetryDownload(itemId: UUID, downloadDatabaseDao: DownloadDatabaseDao, con
 
 fun isItemDownloaded(downloadDatabaseDao: DownloadDatabaseDao, itemId: UUID): Boolean {
     val item = downloadDatabaseDao.loadItem(itemId)
-    return item != null
+    if (item != null) {
+        return File(defaultStorage, item.id.toString()).exists() && File(defaultStorage, "${item.id}.downloading").exists()
+    }
+    return false
 }
 
 fun getDownloadPlayerItem(downloadDatabase: DownloadDatabaseDao, itemId: UUID): PlayerItem? {


### PR DESCRIPTION
If the user clicks on the download button and if the media do not exist in File-System but exist it DB. Then it will delete the previous DB entry and create a new one and start the download.

[#210 ](https://github.com/jarnedemeulemeester/findroid/issues/210)