### PR TITLE
fix: remember scroll position in `LibraryFragment`

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/LibraryFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/LibraryFragment.kt
@@ -150,6 +150,8 @@ class LibraryFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                if (viewModel.itemsloaded) return@repeatOnLifecycle
+
                 // Sorting options
                 val sortBy = SortBy.fromString(preferences.sortBy)
                 val sortOrder = try {

--- a/core/src/main/java/dev/jdtech/jellyfin/viewmodels/LibraryViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/viewmodels/LibraryViewModel.kt
@@ -3,6 +3,7 @@ package dev.jdtech.jellyfin.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.jdtech.jellyfin.repository.JellyfinRepository
 import dev.jdtech.jellyfin.models.SortBy
@@ -26,6 +27,8 @@ constructor(
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState = _uiState.asStateFlow()
 
+    var itemsloaded = false
+
     sealed class UiState {
         data class Normal(val items: Flow<PagingData<BaseItemDto>>) : UiState()
         object Loading : UiState()
@@ -38,6 +41,7 @@ constructor(
         sortBy: SortBy = SortBy.defaultValue,
         sortOrder: SortOrder = SortOrder.ASCENDING
     ) {
+        itemsloaded = true
         Timber.d("$libraryType")
         val itemType = when (libraryType) {
             "movies" -> listOf(BaseItemKind.MOVIE)
@@ -54,7 +58,7 @@ constructor(
                     recursive = true,
                     sortBy = sortBy,
                     sortOrder = sortOrder
-                )
+                ).cachedIn(viewModelScope)
                 _uiState.emit(UiState.Normal(items))
             } catch (e: Exception) {
                 _uiState.emit(UiState.Error(e))


### PR DESCRIPTION
Remember scroll position in `LibraryFragment` by using caching and only loading the pager once.

Fix: #201 