### PR TITLE
fix: Implementation of Mandatory System Gesture Insets to Avoid Conflicts with System Gestures

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -19,8 +19,8 @@ import dev.jdtech.jellyfin.AppPreferences
 import dev.jdtech.jellyfin.Constants
 import dev.jdtech.jellyfin.PlayerActivity
 import dev.jdtech.jellyfin.mpv.MPVPlayer
-import timber.log.Timber
 import kotlin.math.abs
+import timber.log.Timber
 
 class PlayerGestureHelper(
     private val appPreferences: AppPreferences,
@@ -280,14 +280,15 @@ class PlayerGestureHelper(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val insets = playerView.rootWindowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.systemGestures())
 
-            if ((firstEvent.x < insets.left) || (firstEvent.x > (screenWidth - insets.right))
-                || (firstEvent.y < insets.top) || (firstEvent.y > (screenHeight - insets.bottom)))
+            if ((firstEvent.x < insets.left) || (firstEvent.x > (screenWidth - insets.right)) ||
+                (firstEvent.y < insets.top) || (firstEvent.y > (screenHeight - insets.bottom))
+            )
                 return true
-
         } else if (firstEvent.y < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_VERTICAL) ||
-            firstEvent.y > screenHeight-playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_VERTICAL) ||
+            firstEvent.y > screenHeight - playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_VERTICAL) ||
             firstEvent.x < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_HORIZONTAL) ||
-            firstEvent.x > screenWidth-playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_HORIZONTAL))
+            firstEvent.x > screenWidth - playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_HORIZONTAL)
+        )
             return true
         return false
     }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -88,17 +88,8 @@ class PlayerGestureHelper(
                 distanceX: Float,
                 distanceY: Float
             ): Boolean {
-
                 // Excludes area where app gestures conflicting with system gestures
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    val insets = playerView.rootWindowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.systemGestures())
-
-                    if ((firstEvent.x < insets.left) || (firstEvent.x > (screenWidth - insets.right))
-                        || (firstEvent.y < insets.top) || (firstEvent.y > (screenHeight - insets.bottom)))
-                        return false
-
-                } else if (firstEvent.y < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_TOP))
-                    return false
+                if (inExclusionArea(firstEvent)) return false
 
                 // Check whether swipe was oriented vertically
                 if (abs(distanceY / distanceX) < 2) {
@@ -135,17 +126,8 @@ class PlayerGestureHelper(
                 distanceX: Float,
                 distanceY: Float
             ): Boolean {
-
                 // Excludes area where app gestures conflicting with system gestures
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    val insets = playerView.rootWindowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.systemGestures())
-
-                    if ((firstEvent.x < insets.left) || (firstEvent.x > (screenWidth - insets.right))
-                        || (firstEvent.y < insets.top) || (firstEvent.y > (screenHeight - insets.bottom)))
-                        return false
-
-                } else if (firstEvent.y < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_TOP))
-                    return false
+                if (inExclusionArea(firstEvent)) return false
 
                 if (abs(distanceY / distanceX) < 2) return false
 
@@ -289,6 +271,25 @@ class PlayerGestureHelper(
         val seconds = abs(duration).div(1000)
 
         return String.format("%s%02d:%02d:%02d", sign, seconds / 3600, (seconds / 60) % 60, seconds % 60)
+    }
+
+    /**
+     * Check if [firstEvent] is in the gesture exclusion area
+     */
+    private fun inExclusionArea(firstEvent: MotionEvent): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val insets = playerView.rootWindowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.systemGestures())
+
+            if ((firstEvent.x < insets.left) || (firstEvent.x > (screenWidth - insets.right))
+                || (firstEvent.y < insets.top) || (firstEvent.y > (screenHeight - insets.bottom)))
+                return true
+
+        } else if (firstEvent.y < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_VERTICAL) ||
+            firstEvent.y > screenHeight-playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_VERTICAL) ||
+            firstEvent.x < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_HORIZONTAL) ||
+            firstEvent.x > screenWidth-playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_HORIZONTAL))
+            return true
+        return false
     }
 
     init {

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -135,7 +135,16 @@ class PlayerGestureHelper(
                 distanceX: Float,
                 distanceY: Float
             ): Boolean {
-                if (firstEvent.y < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_TOP))
+
+                // Excludes area where app gestures conflicting with system gestures
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val insets = playerView.rootWindowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.systemGestures())
+
+                    if ((firstEvent.x < insets.left) || (firstEvent.x > (screenWidth - insets.right))
+                        || (firstEvent.y < insets.top) || (firstEvent.y > (screenHeight - insets.bottom)))
+                        return false
+
+                } else if (firstEvent.y < playerView.resources.dip(Constants.GESTURE_EXCLUSION_AREA_TOP))
                     return false
 
                 if (abs(distanceY / distanceX) < 2) return false

--- a/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
@@ -2,7 +2,8 @@ package dev.jdtech.jellyfin
 
 object Constants {
     // player
-    const val GESTURE_EXCLUSION_AREA_TOP = 48
+    const val GESTURE_EXCLUSION_AREA_VERTICAL = 48
+    const val GESTURE_EXCLUSION_AREA_HORIZONTAL = 24
     const val FULL_SWIPE_RANGE_SCREEN_RATIO = 0.66f
     const val ZOOM_SCALE_BASE = 1f
     const val ZOOM_SCALE_THRESHOLD = 0.01f


### PR DESCRIPTION
- Previously, the use of system gestures (such as the back and home gestures) resulted in the invocation of app gestures (such as seek, volume and brightness gestures), causing conflicts with the system gestures.
- This PR solves the issue of conflicting gestures by adding mandatory system gesture insets. These insets represent the areas of the window where system gestures have priority. This implementation is in line with the guidelines provided by the Android Developers website. And also this closes #281 