### PR TITLE
ci: split build job into lint and assemble

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: Build
+  lint:
+    name: Lint
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -21,7 +21,24 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
-        run: ./gradlew lintDebug ktlintCheck assembleDebug
+        run: ./gradlew lintDebug ktlintCheck
+  assemble:
+    name: Assemble
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: temurin
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug
         # Upload all build artifacts in separate steps. This can be shortened once https://github.com/actions/upload-artifact/pull/354 is merged.
       - name: Upload artifact phone-universal-debug.apk
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Split the build job into lint and assemble.
This way we still have APK artifacts even when the linting fails.