### PR TITLE
fix: volume gesture tracker value does not stay within bounds

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -148,15 +148,14 @@ class PlayerGestureHelper(
 
                     val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
                     val change = ratioChange * maxVolume
-                    swipeGestureValueTrackerVolume += change
+                    swipeGestureValueTrackerVolume = (swipeGestureValueTrackerVolume + change).coerceIn(0f, maxVolume.toFloat())
 
-                    val toSet = swipeGestureValueTrackerVolume.toInt().coerceIn(0, maxVolume)
-                    audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, toSet, 0)
+                    audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, swipeGestureValueTrackerVolume.toInt(), 0)
 
                     activity.binding.gestureVolumeLayout.visibility = View.VISIBLE
                     activity.binding.gestureVolumeProgressBar.max = maxVolume
-                    activity.binding.gestureVolumeProgressBar.progress = toSet
-                    activity.binding.gestureVolumeText.text = "${(toSet.toFloat() / maxVolume.toFloat()).times(100).toInt()}%"
+                    activity.binding.gestureVolumeProgressBar.progress = swipeGestureValueTrackerVolume.toInt()
+                    activity.binding.gestureVolumeText.text = "${(swipeGestureValueTrackerVolume / maxVolume.toFloat()).times(100).toInt()}%"
 
                     swipeGestureVolumeOpen = true
                 } else {


### PR DESCRIPTION
Previously, when swiping up to increase the volume to its maximum level and keeps swiping up causes the volume tracker value to increase as much as we swipe, swiping down afterwards would not adjust the volume until the volume tracker value reached the maximum volume value. This issue has been resolved so that volume adjustment occurs immediately after swiping down.