### PR TITLE
feat: ability to change number of covers in libraries

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/LibraryFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/LibraryFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.paging.LoadState
+import androidx.recyclerview.widget.GridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import dev.jdtech.jellyfin.AppPreferences
 import dev.jdtech.jellyfin.adapters.ViewItemPagingAdapter
@@ -61,6 +62,8 @@ class LibraryFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding.itemsRecyclerView.layoutManager = GridLayoutManager(context, preferences.spanCount)
 
         val menuHost: MenuHost = requireActivity()
         menuHost.addMenuProvider(

--- a/core/src/main/res/xml/fragment_settings_appearance.xml
+++ b/core/src/main/res/xml/fragment_settings_appearance.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <ListPreference
         app:defaultValue="system"
         app:entries="@array/themes"
@@ -22,4 +23,12 @@
         app:key="pref_display_extra_info"
         app:summary="@string/extra_info_summary"
         app:title="@string/extra_info" />
+    <SeekBarPreference
+        app:defaultValue="2"
+        app:key="pref_span_count"
+        android:max="5"
+        app:seekBarIncrement="1"
+        app:min="1"
+        app:showSeekBarValue="true"
+        app:title="Number of rows in libraries view" />
 </PreferenceScreen>

--- a/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
@@ -34,6 +34,7 @@ constructor(
     val theme get() = sharedPreferences.getString(Constants.PREF_THEME, null)
     val dynamicColors get() = sharedPreferences.getBoolean(Constants.PREF_DYNAMIC_COLORS, true)
     val amoledTheme get() = sharedPreferences.getBoolean(Constants.PREF_AMOLED_THEME, false)
+    val spanCount get() = sharedPreferences.getInt(Constants.PREF_SPAN_NO, 2)
     var displayExtraInfo: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_DISPLAY_EXTRA_INFO, false)
         set(value) {

--- a/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
@@ -34,6 +34,7 @@ object Constants {
     const val PREF_THEME = "theme"
     const val PREF_DYNAMIC_COLORS = "dynamic_colors"
     const val PREF_AMOLED_THEME = "pref_amoled_theme"
+    const val PREF_SPAN_NO = "pref_span_count"
     const val PREF_NETWORK_REQUEST_TIMEOUT = "pref_network_request_timeout"
     const val PREF_NETWORK_CONNECT_TIMEOUT = "pref_network_connect_timeout"
     const val PREF_NETWORK_SOCKET_TIMEOUT = "pref_network_socket_timeout"


### PR DESCRIPTION
**Add ability to change number of movies/shows covers in the libraries sections.**

By default, for the libraries, Findroid uses a grid that is made of only 2 rows. This works fine if you don't have a lot of movies in your library, however it becomes a burden to navigate once you have a big library with a lot of movies and shows.
This feature adds a SeekBar in the "Appearance" section in the preference menu, which allows the user to change the number of rows (minimum 1, maximum 5). This changes the number of rows in the RecyclerView in both the Shows and Movies section.

**Screenshots:**

**_Default (2 rows) left, new (3 rows) right_**
![default 2](https://github.com/jarnedemeulemeester/findroid/assets/52109183/4d6fd03c-c85f-4d92-b309-57de15ca5f37) ![new 3](https://github.com/jarnedemeulemeester/findroid/assets/52109183/9a552c21-ddaa-476d-a37b-16b15af0cfd3)

Settings Menu:

![settings](https://github.com/jarnedemeulemeester/findroid/assets/52109183/779bfbb0-2607-46ef-bf87-75235960c254)

**Possible things to add:**

- Vibrations when changing the value of SeekBarPreference
- 3 rows instead of 2 by default
- Change the size of the cover art when changing the value of the SeekBar (when selecting 2, make the cover art smaller, when selecting 3, make them bigger, etc...)

Let me know of any bugs.


