### PR TITLE
feat(atv): add `LEANBACK_LAUNCHER` category

### DIFF
--- a/app/phone/src/main/AndroidManifest.xml
+++ b/app/phone/src/main/AndroidManifest.xml
@@ -10,11 +10,20 @@
         android:name="android.hardware.wifi"
         android:required="false" />
 
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
     <application
         android:name=".BaseApplication"
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupOnly="true"
+        android:banner="@mipmap/ic_launcher"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
@@ -33,7 +42,9 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
 
         </activity>


### PR DESCRIPTION
Add `LEANBACK_LAUNCHER` category so that the builds can be directly shown in the apps panel on Android TV's.