### PR TITLE
feat: requeue pending downloads on downloads preference change

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/SettingsFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/SettingsFragment.kt
@@ -8,6 +8,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import dagger.hilt.android.AndroidEntryPoint
 import dev.jdtech.jellyfin.AppPreferences
+import dev.jdtech.jellyfin.utils.Downloader
 import dev.jdtech.jellyfin.utils.restart
 import javax.inject.Inject
 import dev.jdtech.jellyfin.core.R as CoreR
@@ -16,6 +17,9 @@ import dev.jdtech.jellyfin.core.R as CoreR
 class SettingsFragment : PreferenceFragmentCompat() {
     @Inject
     lateinit var appPreferences: AppPreferences
+
+    @Inject
+    lateinit var downloader: Downloader
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(CoreR.xml.fragment_settings, rootKey)
@@ -54,6 +58,14 @@ class SettingsFragment : PreferenceFragmentCompat() {
         findPreference<Preference>("appInfo")?.setOnPreferenceClickListener {
             findNavController().navigate(TwoPaneSettingsFragmentDirections.actionSettingsFragmentToAboutLibraries())
             true
+        }
+
+        // Re-download pending items when a download preference has changed.
+        // https://stackoverflow.com/questions/29476741/executing-code-after-a-preference-has-been-changed
+        appPreferences.sharedPreferences.registerOnSharedPreferenceChangeListener { _, key ->
+            if (key.startsWith("pref_downloads_")) {
+                downloader.requeuePendingItems()
+            }
         }
     }
 }

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/Downloader.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/Downloader.kt
@@ -16,4 +16,6 @@ interface Downloader {
     suspend fun deleteItem(item: FindroidItem, source: FindroidSource)
 
     suspend fun getProgress(downloadId: Long?): Pair<Int, Int>
+
+    fun requeuePendingItems()
 }

--- a/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class AppPreferences
 @Inject
 constructor(
-    private val sharedPreferences: SharedPreferences,
+    val sharedPreferences: SharedPreferences,
 ) {
     // Server
     var currentServer: String?


### PR DESCRIPTION
resolves #430

---

This feature requeues all pending download items when changing the 'Downloads' preferences, which saves the user from needing to cancel all pending downloads and download them again manually.

This only addresses the downloading problem mentioned in #430, but as mentioned there, the case when a user turns off either of the 'Downloads' preferences, it's possible to cancel the downloads from the notification tab. 
