### PR TITLE
WIP: Add pending downloads prompt

### DIFF
--- a/app/phone/src/main/res/navigation/app_navigation.xml
+++ b/app/phone/src/main/res/navigation/app_navigation.xml
@@ -220,6 +220,13 @@
         <action
             android:id="@+id/action_episodeBottomSheetFragment_to_showFragment"
             app:destination="@id/showFragment" />
+        <action
+            android:id="@+id/action_episodeBottomSheetFragment_to_settingsFragment"
+            app:destination="@id/twoPaneSettingsFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
     </dialog>
     <fragment
         android:id="@+id/favoriteFragment"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -173,5 +173,11 @@
     <string name="cancel_download">Cancel download</string>
     <string name="cancel_download_message">Are you sure you want to cancel the download?</string>
     <string name="stop_download">Stop download</string>
+    <string name="download_is_pending">Your download is pending</string>
+    <string name="pending_download_message">Go to Downloads settings to change preferences</string>
+    <string name="go_to_download_settings">Go to settings</string>
+    <string name="wait_for_download">Wait for download</string>
+    <string name="dont_ask_again">Don\'t ask again</string>
+    <string name="download_prompt_pending">Don\'t ask again</string>
     <string name="privacy_policy_notice">By using Findroid you agree with the <a href='https://raw.githubusercontent.com/jarnedemeulemeester/findroid/main/PRIVACY'>Privacy Policy</a> which states that we do not collect any data</string>
 </resources>

--- a/core/src/main/res/xml/fragment_settings_downloads.xml
+++ b/core/src/main/res/xml/fragment_settings_downloads.xml
@@ -9,4 +9,8 @@
         android:defaultValue="false"
         app:key="pref_downloads_roaming"
         app:title="@string/download_roaming" />
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        app:key="pref_downloads_prompt_pending"
+        app:title="@string/download_prompt_pending" />
 </PreferenceScreen>

--- a/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
@@ -121,6 +121,12 @@ constructor(
         false,
     )
 
+    var promptPendingDownloads: Boolean
+        get() = sharedPreferences.getBoolean(Constants.PREF_PROMPT_PENDING_DOWNLOADS, true)
+        set(value) = sharedPreferences.edit {
+            putBoolean(Constants.PREF_PROMPT_PENDING_DOWNLOADS, value)
+        }
+
     // Sorting
     var sortBy: String
         get() = sharedPreferences.getString(

--- a/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
@@ -39,6 +39,7 @@ object Constants {
     const val PREF_NETWORK_SOCKET_TIMEOUT = "pref_network_socket_timeout"
     const val PREF_DOWNLOADS_MOBILE_DATA = "pref_downloads_mobile_data"
     const val PREF_DOWNLOADS_ROAMING = "pref_downloads_roaming"
+    const val PREF_PROMPT_PENDING_DOWNLOADS = "pref_downloads_prompt_pending"
     const val PREF_SORT_BY = "pref_sort_by"
     const val PREF_SORT_ORDER = "pref_sort_order"
     const val PREF_DISPLAY_EXTRA_INFO = "pref_display_extra_info"


### PR DESCRIPTION
Currently it's not a-lot, just added a check in the download pending callback to open a prompt if a preference is enabled (by default)

Can be disabled in the downloads settings

Prompt has 2 buttons:
1. Go to settings
2. Wait for download

I'm not adding the option to change preference from the prompt because it's unknown if it's because of the mobile data or roaming (or any other reason that may be introduced in the future)

Join [Discord group](https://discord.com/channels/900813402056851496/1127466150738001991) to help :)