### PR TITLE
feat: Add seek and play/pause functionality to onDoubleTap

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -68,13 +68,33 @@ class PlayerGestureHelper(
             override fun onDoubleTap(e: MotionEvent): Boolean {
                 // Disables double tap gestures if view is locked
                 if (isControlsLocked) return false
-                val viewCenterX = playerView.measuredWidth / 2
+
+                val viewWidth = playerView.measuredWidth
+                val areaWidth = viewWidth / 5 // Divide the view into 5 parts: 2:1:2
+
                 val currentPos = playerView.player?.currentPosition ?: 0
 
-                if (e.x.toInt() > viewCenterX) {
-                    playerView.player?.seekTo(currentPos + appPreferences.playerSeekForwardIncrement)
-                } else {
-                    playerView.player?.seekTo((currentPos - appPreferences.playerSeekBackIncrement).coerceAtLeast(0))
+                // Define the areas and their boundaries
+                val leftmostAreaStart = 0
+                val leftmostAreaEnd = areaWidth * 2
+                val middleAreaStart = leftmostAreaEnd
+                val middleAreaEnd = middleAreaStart + areaWidth
+                val rightmostAreaStart = middleAreaEnd
+                val rightmostAreaEnd = viewWidth
+
+                when {
+                    e.x.toInt() in leftmostAreaStart until leftmostAreaEnd -> {
+                        // Tapped on the leftmost area (seek backward)
+                        playerView.player?.seekTo((currentPos - appPreferences.playerSeekBackIncrement).coerceAtLeast(0))
+                    }
+                    e.x.toInt() in middleAreaStart until middleAreaEnd -> {
+                        // Tapped on the middle area (toggle pause/unpause)
+                        playerView.player?.playWhenReady = !playerView.player?.playWhenReady!!
+                    }
+                    e.x.toInt() in rightmostAreaStart until rightmostAreaEnd -> {
+                        // Tapped on the rightmost area (seek forward)
+                        playerView.player?.seekTo(currentPos + appPreferences.playerSeekForwardIncrement)
+                    }
                 }
                 return true
             }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -76,22 +76,19 @@ class PlayerGestureHelper(
 
                 // Define the areas and their boundaries
                 val leftmostAreaStart = 0
-                val leftmostAreaEnd = areaWidth * 2
-                val middleAreaStart = leftmostAreaEnd
-                val middleAreaEnd = middleAreaStart + areaWidth
-                val rightmostAreaStart = middleAreaEnd
-                val rightmostAreaEnd = viewWidth
+                val middleAreaStart = areaWidth * 2
+                val rightmostAreaStart = middleAreaStart + areaWidth
 
-                when {
-                    e.x.toInt() in leftmostAreaStart until leftmostAreaEnd -> {
+                when (e.x.toInt()) {
+                    in leftmostAreaStart until middleAreaStart -> {
                         // Tapped on the leftmost area (seek backward)
                         playerView.player?.seekTo((currentPos - appPreferences.playerSeekBackIncrement).coerceAtLeast(0))
                     }
-                    e.x.toInt() in middleAreaStart until middleAreaEnd -> {
+                    in middleAreaStart until rightmostAreaStart -> {
                         // Tapped on the middle area (toggle pause/unpause)
                         playerView.player?.playWhenReady = !playerView.player?.playWhenReady!!
                     }
-                    e.x.toInt() in rightmostAreaStart until rightmostAreaEnd -> {
+                    in rightmostAreaStart until viewWidth -> {
                         // Tapped on the rightmost area (seek forward)
                         playerView.player?.seekTo(currentPos + appPreferences.playerSeekForwardIncrement)
                     }


### PR DESCRIPTION
This patch enhances the `onDoubleTap` method within the media player component. It introduces a split-screen layout where the player view is divided into three equal areas (in the ratio of 2:1:2).

1. Leftmost Area: When double-tapped, it seeks the media playback backward by the defined seek increment
(`appPreferences.playerSeekBackIncrement`).

2. Middle Area: A double-tap in this area toggles the play/pause state of the player. If the player is currently playing, it will be paused, and if it's paused, it will be resumed.

3. Rightmost Area: When double-tapped, it seeks the media playback forward by the specified seek increment
(`appPreferences.playerSeekForwardIncrement`).