### PR TITLE
build: up min sdk to 28

### DIFF
--- a/app/phone/build.gradle.kts
+++ b/app/phone/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId = "dev.jdtech.jellyfin"
-        minSdk = 27
+        minSdk = 28
         targetSdk = 34
 
         val appVersionCode: Int by rootProject.extra

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/BasePlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/BasePlayerActivity.kt
@@ -1,6 +1,5 @@
 package dev.jdtech.jellyfin
 
-import android.os.Build
 import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/BasePlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/BasePlayerActivity.kt
@@ -51,10 +51,8 @@ abstract class BasePlayerActivity : AppCompatActivity() {
             )
 
         window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            window.attributes.layoutInDisplayCutoutMode =
-                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-        }
+        window.attributes.layoutInDisplayCutoutMode =
+            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
     }
 
     protected fun isRendererType(
@@ -71,18 +69,16 @@ abstract class BasePlayerActivity : AppCompatActivity() {
     }
 
     protected fun configureInsets(playerControls: View) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            playerControls
-                .setOnApplyWindowInsetsListener { _, windowInsets ->
-                    val cutout = windowInsets.displayCutout
-                    playerControls.updatePadding(
-                        left = cutout?.safeInsetLeft ?: 0,
-                        top = cutout?.safeInsetTop ?: 0,
-                        right = cutout?.safeInsetRight ?: 0,
-                        bottom = cutout?.safeInsetBottom ?: 0,
-                    )
-                    return@setOnApplyWindowInsetsListener windowInsets
-                }
-        }
+        playerControls
+            .setOnApplyWindowInsetsListener { _, windowInsets ->
+                val cutout = windowInsets.displayCutout
+                playerControls.updatePadding(
+                    left = cutout?.safeInsetLeft ?: 0,
+                    top = cutout?.safeInsetTop ?: 0,
+                    right = cutout?.safeInsetRight ?: 0,
+                    bottom = cutout?.safeInsetBottom ?: 0,
+                )
+                return@setOnApplyWindowInsetsListener windowInsets
+            }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 28
     }
 
     buildTypes {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 28
 
         val appVersionCode: Int by rootProject.extra
         val appVersionName: String by rootProject.extra

--- a/player/core/build.gradle.kts
+++ b/player/core/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 28
     }
 
     buildTypes {

--- a/player/video/build.gradle.kts
+++ b/player/video/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 28
     }
 
     buildTypes {

--- a/preferences/build.gradle.kts
+++ b/preferences/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 28
     }
 
     buildTypes {


### PR DESCRIPTION
Up the minimum SDK to 28 (Android 9).

Of all installs on Google Play less then 1% is on Android 8.1, so I think we can drop this version.
This also allows us to remove some Android 9 specific checks.

However this change does increase the generated APK's file sizes. This is because starting with minSdk 28 the dex files are uncompressed by default. See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/DexPackaging?hl=en#useLegacyPackaging()
This does not affect APK's generated from AAB like what the Google Play Store does.

For now I will not enable `useLegacyPackaging`, but if APK size becomes a problem then this could be enabled.