### PR TITLE
fix episode indicator wrapping on second line

### DIFF
--- a/app/phone/src/main/res/layout/base_item.xml
+++ b/app/phone/src/main/res/layout/base_item.xml
@@ -59,11 +59,13 @@
 
         <TextView
             android:id="@+id/item_count"
-            android:layout_width="24dp"
+            android:layout_width="wrap_content"
             android:layout_height="24dp"
             android:layout_marginStart="8dp"
-            android:background="@drawable/circle_background"
+            android:background="@drawable/bg_rounded_rect_12dp"
             android:gravity="center"
+            android:minWidth="24dp"
+            android:paddingHorizontal="8dp"
             android:textAppearance="@style/TextAppearance.Material3.BodySmall"
             android:textColor="?attr/colorOnPrimary"
             app:layout_constraintEnd_toEndOf="parent"

--- a/core/src/main/res/drawable/bg_rounded_rect_12dp.xml
+++ b/core/src/main/res/drawable/bg_rounded_rect_12dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="12dp" />
+    <solid android:color="?attr/colorPrimary" />
+</shape>


### PR DESCRIPTION
Fixes #445

The episode indicator background was constrained to a 24dp box. If this box could not contain the count, then the count would wrap onto a new line.

The proposed solution is to use a rounded rectangle as the background instead. This can then expand into a chip as needed to accommodate larger numbers without wrapping.

See below how this looks like with 1, 2, and 4 digits:
<img src="https://github.com/jarnedemeulemeester/findroid/assets/139957/ae6efc4d-0923-442e-8694-6781ddfb1acb" width="300">