### PR TITLE
set sort order for collection view to release date

### DIFF
--- a/core/src/main/java/dev/jdtech/jellyfin/viewmodels/CollectionViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/viewmodels/CollectionViewModel.kt
@@ -9,6 +9,7 @@ import dev.jdtech.jellyfin.models.FavoriteSection
 import dev.jdtech.jellyfin.models.FindroidEpisode
 import dev.jdtech.jellyfin.models.FindroidMovie
 import dev.jdtech.jellyfin.models.FindroidShow
+import dev.jdtech.jellyfin.models.SortBy
 import dev.jdtech.jellyfin.models.UiText
 import dev.jdtech.jellyfin.repository.JellyfinRepository
 import kotlinx.coroutines.Dispatchers
@@ -39,7 +40,7 @@ constructor(
             _uiState.emit(UiState.Loading)
 
             try {
-                val items = jellyfinRepository.getItems(parentId = parentId)
+                val items = jellyfinRepository.getItems(parentId = parentId, sortBy = SortBy.RELEASE_DATE)
 
                 if (items.isEmpty()) {
                     _uiState.emit(UiState.Normal(emptyList()))


### PR DESCRIPTION
Until there's an option to set the order in collection views I believe the default should be by RELEASE_DATE, other FJ interfaces do it like this as well and it just makes the most sense.

Related issues:
#384 