### PR TITLE
fix: snackbar not showing in landscape mode

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/DownloadsFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/DownloadsFragment.kt
@@ -58,7 +58,7 @@ class DownloadsFragment : Fragment() {
                 launch {
                     viewModel.connectionError.collect {
                         Snackbar.make(binding.root, CoreR.string.no_server_connection, Snackbar.LENGTH_INDEFINITE)
-                            .setAnchorView(requireActivity().findViewById(R.id.nav_view))
+                            .setTextMaxLines(2)
                             .setAction(CoreR.string.offline_mode) {
                                 appPreferences.offlineMode = true
                                 activity?.restart()

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/DownloadsFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/DownloadsFragment.kt
@@ -14,7 +14,6 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import dev.jdtech.jellyfin.AppPreferences
-import dev.jdtech.jellyfin.R
 import dev.jdtech.jellyfin.adapters.FavoritesListAdapter
 import dev.jdtech.jellyfin.adapters.HomeEpisodeListAdapter
 import dev.jdtech.jellyfin.adapters.ViewItemListAdapter


### PR DESCRIPTION
This affected also all tablets since they use the landscape view!

Added `setTextMaxLines` because for some reason the text is truncated on tablets.

- Fixes #470.

Thanks @Jcuhfehl for the help :D