### PR TITLE
feat: sleep mode

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -438,7 +438,8 @@ class PlayerActivity : BasePlayerActivity() {
     }
 
     private fun showSleepTimerDurationDialog() {
-        val timerTexts = listOf("1 minute", "5 minutes", "10 minutes", "30 minutes", "1 hour", "2 hours")
+        val timerTexts =
+            listOf("1 minute", "5 minutes", "10 minutes", "30 minutes", "1 hour", "2 hours")
         val durationValues = longArrayOf(60000L, 300000L, 600000L, 1800000L, 3600000L, 7200000L)
         var selectedDuration = durationValues[2] // Default: 10 minutes in milliseconds
 
@@ -461,8 +462,7 @@ class PlayerActivity : BasePlayerActivity() {
                 dialog.dismiss()
             }
             .setCancelable(true)
-            wasDialogShown = true
-
+        wasDialogShown = true
         builder.create().show()
     }
 

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -174,7 +174,7 @@ class PlayerActivity : BasePlayerActivity() {
                                 speedButton.imageAlpha = 255
                                 pipButton.isEnabled = true
                                 pipButton.imageAlpha = 255
-								sleepModeButton.isEnabled = appPreferences.sleepMode
+                                sleepModeButton.isEnabled = appPreferences.sleepMode
                                 sleepModeButton.imageAlpha = if (appPreferences.sleepMode) {
                                     255
                                 } else {

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -66,7 +66,7 @@ class PlayerActivity : BasePlayerActivity() {
     override val viewModel: PlayerActivityViewModel by viewModels()
     private var previewScrubListener: PreviewScrubListener? = null
     private var sleepJob: Job? = null
-    private var wasDialogShown : Boolean = false
+    private var wasDialogShown: Boolean = false
     private var isSleepModeEnabled: Boolean = false
 
     private val isPipSupported by lazy {
@@ -174,7 +174,7 @@ class PlayerActivity : BasePlayerActivity() {
                                 speedButton.imageAlpha = 255
                                 pipButton.isEnabled = true
                                 pipButton.imageAlpha = 255
-                                if(appPreferences.sleepMode) {
+                                if (appPreferences.sleepMode) {
                                     sleepModeButton.isEnabled = true
                                     sleepModeButton.imageAlpha = 255
                                 } else {
@@ -326,7 +326,6 @@ class PlayerActivity : BasePlayerActivity() {
             }
         }
 
-
         sleepModeUnlockButton.setOnClickListener{
             disableSleepMode()
             isSleepModeEnabled = false
@@ -447,7 +446,7 @@ class PlayerActivity : BasePlayerActivity() {
         builder.setTitle("Select Sleep Timer Duration")
             .setSingleChoiceItems(
                 timerTexts.toTypedArray(),
-                timerTexts.indexOf("${selectedDuration / 60000} minutes")
+                timerTexts.indexOf("${selectedDuration / 60000} minutes"),
             ) { _, which ->
                 selectedDuration = durationValues[which]
             }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -52,8 +52,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-import dev.jdtech.jellyfin.player.video.R as PlayerVideoR
 import dev.jdtech.jellyfin.core.R as CoreR
+import dev.jdtech.jellyfin.player.video.R as PlayerVideoR
 
 var isControlsLocked: Boolean = false
 
@@ -464,7 +464,7 @@ class PlayerActivity : BasePlayerActivity() {
         wasDialogShown = true
         builder.create().show()
     }
-    
+
     private fun disableSleepMode() {
         binding.playerView.player?.playWhenReady = true
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -482,35 +482,35 @@ class PlayerActivity : BasePlayerActivity() {
         val hourText = resources.getQuantityString(
             CoreR.plurals.hour,
             hours.toInt(),
-            hours
+            hours,
         )
 
         val minuteText = resources.getQuantityString(
             CoreR.plurals.minute,
             minutes.toInt(),
-            minutes
+            minutes,
         )
 
         return when {
             hours > 0 && minutes > 0 ->
                 getString(
                     CoreR.string.sleep_mode_enabled_hours_and_minutes,
-                    hours, // %1$s
-                    hourText, // %2$s
-                    minutes, // %3$s
-                    minuteText // %4$s
+                    hours,
+                    hourText,
+                    minutes,
+                    minuteText,
                 )
             hours > 0 ->
                 getString(
                     CoreR.string.sleep_mode_enabled_hours,
-                    hours, // %1$s
-                    hourText // %2$s
+                    hours,
+                    hourText,
                 )
             else ->
                 getString(
                     CoreR.string.sleep_mode_enabled_minutes,
-                    minutes, // %1$s
-                    minuteText // %2$s
+                    minutes,
+                    minuteText,
                 )
         }
     }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -464,7 +464,7 @@ class PlayerActivity : BasePlayerActivity() {
         wasDialogShown = true
         builder.create().show()
     }
-
+    
     private fun disableSleepMode () {
         binding.playerView.player?.playWhenReady = true
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -465,7 +465,7 @@ class PlayerActivity : BasePlayerActivity() {
         builder.create().show()
     }
 
-    private fun disableSleepMode () {
+    private fun disableSleepMode() {
         binding.playerView.player?.playWhenReady = true
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         binding.playerView.findViewById<FrameLayout>(R.id.sleep_mode_view).visibility = View.GONE

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -174,12 +174,11 @@ class PlayerActivity : BasePlayerActivity() {
                                 speedButton.imageAlpha = 255
                                 pipButton.isEnabled = true
                                 pipButton.imageAlpha = 255
-                                if (appPreferences.sleepMode) {
-                                    sleepModeButton.isEnabled = true
-                                    sleepModeButton.imageAlpha = 255
+								sleepModeButton.isEnabled = appPreferences.sleepMode
+                                sleepModeButton.imageAlpha = if (appPreferences.sleepMode) {
+                                    255
                                 } else {
-                                    sleepModeButton.isEnabled = false
-                                    sleepModeButton.imageAlpha = 0
+                                    0
                                 }
                             }
                         }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -44,7 +44,11 @@ import dev.jdtech.jellyfin.mpv.TrackType
 import dev.jdtech.jellyfin.utils.PlayerGestureHelper
 import dev.jdtech.jellyfin.utils.PreviewScrubListener
 import dev.jdtech.jellyfin.viewmodels.PlayerActivityViewModel
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import dev.jdtech.jellyfin.player.video.R as PlayerVideoR

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -464,7 +464,7 @@ class PlayerActivity : BasePlayerActivity() {
         wasDialogShown = true
         builder.create().show()
     }
-    
+
     private fun disableSleepMode () {
         binding.playerView.player?.playWhenReady = true
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -176,12 +176,8 @@ class PlayerActivity : BasePlayerActivity() {
                                 speedButton.imageAlpha = 255
                                 pipButton.isEnabled = true
                                 pipButton.imageAlpha = 255
-                                sleepModeButton.isEnabled = appPreferences.sleepMode
-                                sleepModeButton.imageAlpha = if (appPreferences.sleepMode) {
-                                    255
-                                } else {
-                                    0
-                                }
+                                sleepModeButton.isVisible = appPreferences.sleepMode
+                                sleepModeButton.imageAlpha = 255
                             }
                         }
                     }
@@ -327,7 +323,7 @@ class PlayerActivity : BasePlayerActivity() {
             }
         }
 
-        sleepModeUnlockButton.setOnClickListener{
+        sleepModeUnlockButton.setOnClickListener {
             disableSleepMode()
             isSleepModeEnabled = false
         }

--- a/app/phone/src/main/res/layout/exo_main_controls.xml
+++ b/app/phone/src/main/res/layout/exo_main_controls.xml
@@ -66,7 +66,14 @@
                 android:contentDescription="@string/enable_sleep_mode"
                 android:padding="16dp"
                 android:src="@drawable/ic_sleep_mode"
-                app:tint="@android:color/white" />
+                android:visibility="gone"
+                app:tint="@android:color/white"
+                tools:visibility="visible" />
+
+            <Space
+                android:layout_width="16dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
 
             <ImageButton
                 android:id="@+id/btn_lockview"
@@ -159,9 +166,9 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="32dp"
             android:background="@drawable/transparent_circle_background"
+            android:contentDescription="@string/player_controls_skip_back"
             android:padding="16dp"
-            android:src="@drawable/ic_skip_back"
-            android:contentDescription="@string/player_controls_skip_back" />
+            android:src="@drawable/ic_skip_back" />
 
         <ImageButton
             android:id="@+id/exo_rew"
@@ -169,9 +176,9 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="32dp"
             android:background="@drawable/transparent_circle_background"
+            android:contentDescription="@string/player_controls_rewind"
             android:padding="16dp"
-            android:src="@drawable/ic_rewind"
-            android:contentDescription="@string/player_controls_rewind" />
+            android:src="@drawable/ic_rewind" />
 
         <ImageButton
             android:id="@+id/exo_play_pause"
@@ -179,10 +186,10 @@
             android:layout_height="wrap_content"
             android:background="@drawable/circle_background"
             android:backgroundTint="@android:color/white"
+            android:contentDescription="@string/player_controls_play_pause"
             android:padding="16dp"
             android:src="@drawable/ic_play"
-            app:tint="@android:color/black"
-            android:contentDescription="@string/player_controls_play_pause" />
+            app:tint="@android:color/black" />
 
         <ImageButton
             android:id="@+id/exo_ffwd"
@@ -190,9 +197,9 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
             android:background="@drawable/transparent_circle_background"
+            android:contentDescription="@string/player_controls_fast_forward"
             android:padding="16dp"
-            android:src="@drawable/ic_fast_forward"
-            android:contentDescription="@string/player_controls_fast_forward" />
+            android:src="@drawable/ic_fast_forward" />
 
         <ImageButton
             android:id="@+id/exo_next"
@@ -200,9 +207,9 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
             android:background="@drawable/transparent_circle_background"
+            android:contentDescription="@string/player_controls_skip_forward"
             android:padding="16dp"
-            android:src="@drawable/ic_skip_forward"
-            android:contentDescription="@string/player_controls_skip_forward" />
+            android:src="@drawable/ic_skip_forward" />
     </LinearLayout>
 
     <LinearLayout
@@ -218,9 +225,9 @@
             android:layout_height="90dp"
             android:layout_gravity="start"
             android:background="@android:color/transparent"
+            android:contentDescription="@string/player_trickplay"
             android:visibility="gone"
-            tools:visibility="visible"
-            android:contentDescription="@string/player_trickplay" />
+            tools:visibility="visible" />
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/phone/src/main/res/layout/exo_main_controls.xml
+++ b/app/phone/src/main/res/layout/exo_main_controls.xml
@@ -57,6 +57,18 @@
             app:layout_constraintTop_toTopOf="parent">
 
             <ImageButton
+                android:id="@+id/btn_sleep_mode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_weight="1"
+                android:background="@drawable/transparent_circle_background"
+                android:contentDescription="@string/enable_sleep_mode"
+                android:padding="16dp"
+                android:src="@drawable/ic_sleep_mode"
+                app:tint="@android:color/white" />
+
+            <ImageButton
                 android:id="@+id/btn_lockview"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/phone/src/main/res/layout/exo_player_control_view.xml
+++ b/app/phone/src/main/res/layout/exo_player_control_view.xml
@@ -4,6 +4,7 @@
     android:layout_height="match_parent">
 
     <include layout="@layout/exo_main_controls"/>
+    <include layout="@layout/sleep_mode_layout"/>
 
     <include
         layout="@layout/exo_locked_controls"

--- a/app/phone/src/main/res/layout/sleep_mode_layout.xml
+++ b/app/phone/src/main/res/layout/sleep_mode_layout.xml
@@ -45,7 +45,7 @@
             android:id="@+id/sleepModeDescription"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/sleep_mode_description"
+            android:text="@string/sleep_mode_enabled_description"
             android:textAlignment="center"
             android:textColor="@color/neutral_200"
             android:textSize="24sp"

--- a/app/phone/src/main/res/layout/sleep_mode_layout.xml
+++ b/app/phone/src/main/res/layout/sleep_mode_layout.xml
@@ -11,12 +11,12 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/sleep_mode_background">
+        android:background="@color/player_background">
 
         <ImageButton
             android:id="@+id/sleep_mode_unlock"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
+            android:layout_width="92dp"
+            android:layout_height="92dp"
             android:layout_gravity="end"
             android:background="@drawable/rounded_corner"
             android:contentDescription="@string/select_playback_speed"
@@ -25,35 +25,33 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sleepModeDescription"
+            app:layout_constraintTop_toBottomOf="@+id/sleep_mode_description"
             app:tint="@android:color/white" />
 
         <TextView
-            android:id="@+id/sleepModeTitle"
+            android:id="@+id/sleep_mode_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/sleep_mode_enabled_title"
+            android:textAlignment="center"
+            android:textAppearance="@style/TextAppearance.Material3.DisplayMedium"
             android:textColor="@color/neutral_200"
-            android:textSize="60sp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/sleep_mode_description"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.129" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/sleepModeDescription"
+            android:id="@+id/sleep_mode_description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/sleep_mode_enabled_description"
             android:textAlignment="center"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
             android:textColor="@color/neutral_200"
-            android:textSize="24sp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/sleep_mode_unlock"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.496"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sleepModeTitle"
-            app:layout_constraintVertical_bias="0.139" />
+            app:layout_constraintTop_toBottomOf="@+id/sleep_mode_title" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/phone/src/main/res/layout/sleep_mode_layout.xml
+++ b/app/phone/src/main/res/layout/sleep_mode_layout.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/sleep_mode_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="gone"
+    tools:visibility="visible">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/sleep_mode_background">
+
+        <ImageButton
+            android:id="@+id/sleep_mode_unlock"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:layout_gravity="end"
+            android:background="@drawable/rounded_corner"
+            android:contentDescription="@string/select_playback_speed"
+            android:padding="16dp"
+            android:src="@drawable/ic_unlock_big"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/sleepModeDescription"
+            app:tint="@android:color/white" />
+
+        <TextView
+            android:id="@+id/sleepModeTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sleep_mode_enabled"
+            android:textColor="@color/neutral_200"
+            android:textSize="60sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.129" />
+
+        <TextView
+            android:id="@+id/sleepModeDescription"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sleep_mode_description"
+            android:textAlignment="center"
+            android:textColor="@color/neutral_200"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.496"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/sleepModeTitle"
+            app:layout_constraintVertical_bias="0.139" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/phone/src/main/res/layout/sleep_mode_layout.xml
+++ b/app/phone/src/main/res/layout/sleep_mode_layout.xml
@@ -32,7 +32,7 @@
             android:id="@+id/sleepModeTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/sleep_mode_enabled"
+            android:text="@string/sleep_mode_enabled_title"
             android:textColor="@color/neutral_200"
             android:textSize="60sp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/CoreExtensions.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/CoreExtensions.kt
@@ -13,6 +13,7 @@ import dev.jdtech.jellyfin.models.CollectionType
 import dev.jdtech.jellyfin.models.View
 import org.jellyfin.sdk.model.api.BaseItemDto
 import java.io.Serializable
+import dev.jdtech.jellyfin.core.R as CoreR
 
 fun BaseItemDto.toView(): View {
     return View(
@@ -47,4 +48,38 @@ fun Activity.restart() {
     val intent = Intent(this, this::class.java)
     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
     startActivity(intent)
+}
+
+fun Long.formatDuration(resources: Resources): String {
+    val hours = (this / 3600L).toInt()
+    val minutes = ((this % 3600L) / 60L).toInt()
+    val seconds = ((this % 3600L) % 60L).toInt()
+
+    val stringParts = mutableListOf<String>()
+
+    if (hours > 0) {
+        val hourText = resources.getQuantityString(
+            CoreR.plurals.hour,
+            hours,
+        )
+        stringParts.add("$hours $hourText")
+    }
+
+    if (minutes > 0) {
+        val minuteText = resources.getQuantityString(
+            CoreR.plurals.minute,
+            minutes,
+        )
+        stringParts.add("$minutes $minuteText")
+    }
+
+    if (seconds > 0) {
+        val secondText = resources.getQuantityString(
+            CoreR.plurals.second,
+            seconds,
+        )
+        stringParts.add("$seconds $secondText")
+    }
+
+    return stringParts.joinToString(" ")
 }

--- a/core/src/main/res/drawable/ic_moon.xml
+++ b/core/src/main/res/drawable/ic_moon.xml
@@ -1,0 +1,8 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000"
+        android:pathData="M12,3a6,6 0,0 0,9 9,9 9,0 1,1 -9,-9Z"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+</vector>

--- a/core/src/main/res/drawable/ic_sleep_mode.xml
+++ b/core/src/main/res/drawable/ic_sleep_mode.xml
@@ -1,0 +1,17 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000" android:pathData="M2,4v16"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000"
+        android:pathData="M2,8h18a2,2 0,0 1,2 2v10"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M2,17h20"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M6,8v9"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+</vector>

--- a/core/src/main/res/drawable/ic_unlock_big.xml
+++ b/core/src/main/res/drawable/ic_unlock_big.xml
@@ -1,12 +1,6 @@
-<vector android:autoMirrored="true" android:height="36dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#00000000"
-        android:pathData="M5,11L19,11A2,2 0,0 1,21 13L21,20A2,2 0,0 1,19 22L5,22A2,2 0,0 1,3 20L3,13A2,2 0,0 1,5 11z"
-        android:strokeColor="@android:color/white" android:strokeLineCap="round"
-        android:strokeLineJoin="round" android:strokeWidth="2"/>
-    <path android:fillColor="#00000000"
-        android:pathData="M7,11V7a5,5 0,0 1,9.9 -1"
-        android:strokeColor="@android:color/white" android:strokeLineCap="round"
-        android:strokeLineJoin="round" android:strokeWidth="2"/>
-</vector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:width="36dp"
+        android:height="36dp"
+        android:drawable="@drawable/ic_unlock" />
+</layer-list>

--- a/core/src/main/res/drawable/ic_unlock_big.xml
+++ b/core/src/main/res/drawable/ic_unlock_big.xml
@@ -1,0 +1,12 @@
+<vector android:autoMirrored="true" android:height="36dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000"
+        android:pathData="M5,11L19,11A2,2 0,0 1,21 13L21,20A2,2 0,0 1,19 22L5,22A2,2 0,0 1,3 20L3,13A2,2 0,0 1,5 11z"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000"
+        android:pathData="M7,11V7a5,5 0,0 1,9.9 -1"
+        android:strokeColor="@android:color/white" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="2"/>
+</vector>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -41,7 +41,6 @@
     <color name="red">#EB5757</color>
     <color name="yellow">#F2C94C</color>
     <color name="player_background">#AA000000</color>
-    <color name="sleep_mode_background">#BE000000</color>
 
     <color name="logo_primary">#FF3DDC84</color>
     <color name="logo_secondary">#FF00A4DC</color>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -41,6 +41,7 @@
     <color name="red">#EB5757</color>
     <color name="yellow">#F2C94C</color>
     <color name="player_background">#AA000000</color>
+    <color name="sleep_mode_background">#BE000000</color>
 
     <color name="logo_primary">#FF3DDC84</color>
     <color name="logo_secondary">#FF00A4DC</color>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -177,4 +177,7 @@
     <string name="cancel_download_message">Are you sure you want to cancel the download?</string>
     <string name="stop_download">Stop download</string>
     <string name="privacy_policy_notice">By using Findroid you agree with the <a href='https://raw.githubusercontent.com/jarnedemeulemeester/findroid/main/PRIVACY'>Privacy Policy</a> which states that we do not collect any data</string>
+    <string name="enable_sleep_mode">Enable Sleep Mode</string>
+    <string name="sleep_mode_enabled">Sleep Mode Enabled</string>
+    <string name="sleep_mode_description">To preserve battery and prevent accidental interactions \nSleep Mode has been activated. \nYour media playback has been pasued. \nTo disable Sleep Mode, press the unlock button below.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -192,17 +192,11 @@
         <item quantity="one">minute</item>
         <item quantity="other">minutes</item>
     </plurals>
-    <string name="sleep_mode_enabled_hours_and_minutes">Sleep Mode will be enabled in %1$s %2$s and %3$s %4$s</string>
-    <string name="sleep_mode_enabled_hours">Sleep Mode will be enabled in %1$s %2$s</string>
-    <string name="sleep_mode_enabled_minutes">Sleep Mode will be enabled in %1$s %2$s</string>
-    <string name="sleep_mode_disabled">Sleep Mode has been disabled</string>
+    <plurals name="second">
+        <item quantity="one">second</item>
+        <item quantity="other">seconds</item>
+    </plurals>
+    <string name="sleep_mode_activated">Sleep Mode will be activated in %1$s</string>
+    <string name="sleep_mode_deactivated">Sleep Mode has been deactivated</string>
     <string name="select_sleep_timer_duration">Select Sleep Timer Duration</string>
-    <string-array name="sleep_timer_durations">
-        <item>1 minute</item>
-        <item>5 minutes</item>
-        <item>10 minutes</item>
-        <item>30 minutes</item>
-        <item>1 hour</item>
-        <item>2 hours</item>
-    </string-array>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -179,7 +179,7 @@
     <string name="privacy_policy_notice">By using Findroid you agree with the <a href='https://raw.githubusercontent.com/jarnedemeulemeester/findroid/main/PRIVACY'>Privacy Policy</a> which states that we do not collect any data</string>
     <string name="enable_sleep_mode">Enable Sleep Mode</string>
     <string name="sleep_mode_enabled">Sleep Mode Enabled</string>
-    <string name="sleep_mode_enabled_description">To preserve battery and prevent accidental interactions \nSleep Mode has been activated. \nYour media playback has been pasued. \nTo disable Sleep Mode, press the unlock button below.</string>
+    <string name="sleep_mode_enabled_description">To preserve battery and prevent accidental interactions \nSleep Mode has been activated. \nYour media playback has been paused. \nTo disable Sleep Mode, press the unlock button below.</string>
     <string name="sleep_mode">Sleep Mode</string>
     <string name="sleep_mode_summary">Toggle Sleep Mode. When toggled on, the app will stop the video playback after a specified amount of time.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -179,5 +179,7 @@
     <string name="privacy_policy_notice">By using Findroid you agree with the <a href='https://raw.githubusercontent.com/jarnedemeulemeester/findroid/main/PRIVACY'>Privacy Policy</a> which states that we do not collect any data</string>
     <string name="enable_sleep_mode">Enable Sleep Mode</string>
     <string name="sleep_mode_enabled">Sleep Mode Enabled</string>
-    <string name="sleep_mode_description">To preserve battery and prevent accidental interactions \nSleep Mode has been activated. \nYour media playback has been pasued. \nTo disable Sleep Mode, press the unlock button below.</string>
+    <string name="sleep_mode_enabled_description">To preserve battery and prevent accidental interactions \nSleep Mode has been activated. \nYour media playback has been pasued. \nTo disable Sleep Mode, press the unlock button below.</string>
+    <string name="sleep_mode">Sleep Mode</string>
+    <string name="sleep_mode_summary">Toggle Sleep Mode. When toggled on, the app will stop the video playback after a specified amount of time.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="remove_server_address_dialog_text">Are you sure you want to remove the server address %1$s</string>
     <string name="remove">Remove</string>
     <string name="cancel">Cancel</string>
+    <string name="set">Set</string>
+    <string name="minutes">Minutes</string>
     <string name="title_home">Home</string>
     <string name="title_media">My media</string>
     <string name="title_favorite">Favorites</string>
@@ -178,8 +180,29 @@
     <string name="stop_download">Stop download</string>
     <string name="privacy_policy_notice">By using Findroid you agree with the <a href='https://raw.githubusercontent.com/jarnedemeulemeester/findroid/main/PRIVACY'>Privacy Policy</a> which states that we do not collect any data</string>
     <string name="enable_sleep_mode">Enable Sleep Mode</string>
-    <string name="sleep_mode_enabled">Sleep Mode Enabled</string>
+    <string name="sleep_mode_enabled_title">Sleep Mode Enabled</string>
     <string name="sleep_mode_enabled_description">To preserve battery and prevent accidental interactions \nSleep Mode has been activated. \nYour media playback has been paused. \nTo disable Sleep Mode, press the unlock button below.</string>
     <string name="sleep_mode">Sleep Mode</string>
     <string name="sleep_mode_summary">Toggle Sleep Mode. When toggled on, the app will stop the video playback after a specified amount of time.</string>
+    <plurals name="hour">
+        <item quantity="one">hour</item>
+        <item quantity="other">hours</item>
+    </plurals>
+    <plurals name="minute">
+        <item quantity="one">minute</item>
+        <item quantity="other">minutes</item>
+    </plurals>
+    <string name="sleep_mode_enabled_hours_and_minutes">Sleep Mode will be enabled in %1$s %2$s and %3$s %4$s</string>
+    <string name="sleep_mode_enabled_hours">Sleep Mode will be enabled in %1$s %2$s</string>
+    <string name="sleep_mode_enabled_minutes">Sleep Mode will be enabled in %1$s %2$s</string>
+    <string name="sleep_mode_disabled">Sleep Mode has been disabled</string>
+    <string name="select_sleep_timer_duration">Select Sleep Timer Duration</string>
+    <string-array name="sleep_timer_durations">
+        <item>1 minute</item>
+        <item>5 minutes</item>
+        <item>10 minutes</item>
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>2 hours</item>
+    </string-array>
 </resources>

--- a/core/src/main/res/xml/fragment_settings_player.xml
+++ b/core/src/main/res/xml/fragment_settings_player.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <Preference
         app:key="pref_player_subtitles"
         app:summary="@string/subtitles_summary"
@@ -113,5 +114,14 @@
             app:title="@string/picture_in_picture_gesture"
             app:summary="@string/picture_in_picture_gesture_summary" />
     </PreferenceCategory>
-    
+    <PreferenceCategory
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        app:title="Sleep Mode">
+            <SwitchPreferenceCompat
+                app:key="pref_sleep_mode_toggle"
+                app:summary="Toggle Sleep Mode. When toggled on, the app will stop the video playback."
+                app:title="Sleep Mode" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/core/src/main/res/xml/fragment_settings_player.xml
+++ b/core/src/main/res/xml/fragment_settings_player.xml
@@ -117,10 +117,10 @@
     <PreferenceCategory
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        app:title="Sleep Mode">
+        app:title="@string/sleep_mode">
             <SwitchPreferenceCompat
                 app:key="pref_sleep_mode_toggle"
-                app:summary="Toggle Sleep Mode. When toggled on, the app will stop the video playback."
+                app:summary="@string/sleep_mode_summary"
                 app:title="Sleep Mode" />
     </PreferenceCategory>
 

--- a/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/AppPreferences.kt
@@ -83,6 +83,8 @@ constructor(
 
     val playerPipGesture get() = sharedPreferences.getBoolean(Constants.PREF_PLAYER_PIP_GESTURE, false)
 
+    val sleepMode get() = sharedPreferences.getBoolean(Constants.PREF_PLAYER_SLEEP_MODE, false)
+
     // Language
     val preferredAudioLanguage get() = sharedPreferences.getString(Constants.PREF_AUDIO_LANGUAGE, "")!!
     val preferredSubtitleLanguage get() = sharedPreferences.getString(Constants.PREF_SUBTITLE_LANGUAGE, "")!!

--- a/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
+++ b/preferences/src/main/java/dev/jdtech/jellyfin/Constants.kt
@@ -29,6 +29,7 @@ object Constants {
     const val PREF_PLAYER_INTRO_SKIPPER = "pref_player_intro_skipper"
     const val PREF_PLAYER_TRICK_PLAY = "pref_player_trick_play"
     const val PREF_PLAYER_PIP_GESTURE = "pref_player_picture_in_picture_gesture"
+    const val PREF_PLAYER_SLEEP_MODE = "pref_sleep_mode_toggle"
     const val PREF_AUDIO_LANGUAGE = "pref_audio_language"
     const val PREF_SUBTITLE_LANGUAGE = "pref_subtitle_language"
     const val PREF_IMAGE_CACHE = "pref_image_cache"


### PR DESCRIPTION
This PR adds a **Sleep Mode** to Findroid.  (Fixes a request on Discord)
At the moment, if the user falls asleep while watching a show, the screen will remain on for the remainder of the show/movie, maybe even more, depending if it's a show or a movie (if it is a show, the rest of the episodes in the series will play). This isn't ideal as it consumes battery needlessly. 
This PR implements a timer that, when it's finished, shows a new screen that explains that Sleep Mode has been enabled and that the screen will turn off on its own to prevent unnecessary battery consumption.
This feature can be disabled in the app's settings if people don't want to have this option (Not sure if this should be removed)

**Screenshots:**

![Screenshot_20230919-122416](https://github.com/jarnedemeulemeester/findroid/assets/52109183/d34dafd5-28bd-40d3-ba4b-6356e1756e06)
_Setting in the Player section_

![Screenshot_20230919-122524](https://github.com/jarnedemeulemeester/findroid/assets/52109183/8e206eee-1542-42f8-9180-82626bc66fc0)
_Button next to the lock button to show the Sleep Mode button_

![Screenshot_20230919-122531](https://github.com/jarnedemeulemeester/findroid/assets/52109183/2656473c-d9cd-46f1-b1e4-6df47e903bce)
_Sleep Mode timer dialog_

![Screenshot_20230919-122650](https://github.com/jarnedemeulemeester/findroid/assets/52109183/9c3675dc-6dc0-414d-b29e-8c0bfb1aac08)
_Sleep Mode screen with unlock button_

**To do:**

- [ ] Test for bugs
- [ ] Add option for "Until media ends" in the dialog
- [ ] Test on big screens

**UPDATE:** Tested it with MPV and it works just fine also.