### PR TITLE
chore: use type-safe project accessors

### DIFF
--- a/app/phone/build.gradle.kts
+++ b/app/phone/build.gradle.kts
@@ -78,11 +78,11 @@ ktlint {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":data"))
-    implementation(project(":preferences"))
-    implementation(project(":player:core"))
-    implementation(project(":player:video"))
+    implementation(projects.core)
+    implementation(projects.data)
+    implementation(projects.preferences)
+    implementation(projects.player.core)
+    implementation(projects.player.video)
     implementation(libs.aboutlibraries.core)
     implementation(libs.aboutlibraries)
     implementation(libs.androidx.activity)

--- a/app/tv/build.gradle.kts
+++ b/app/tv/build.gradle.kts
@@ -82,11 +82,11 @@ ktlint {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":data"))
-    implementation(project(":preferences"))
-    implementation(project(":player:core"))
-    implementation(project(":player:video"))
+    implementation(projects.core)
+    implementation(projects.data)
+    implementation(projects.preferences)
+    implementation(projects.player.core)
+    implementation(projects.player.video)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -53,9 +53,9 @@ ktlint {
 }
 
 dependencies {
-    implementation(project(":data"))
-    implementation(project(":preferences"))
-    implementation(project(":player:core"))
+    implementation(projects.data)
+    implementation(projects.preferences)
+    implementation(projects.player.core)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.compose.ui)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -51,7 +51,7 @@ ktlint {
 }
 
 dependencies {
-    implementation(project(":preferences"))
+    implementation(projects.preferences)
     implementation(libs.androidx.paging)
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)

--- a/player/core/build.gradle.kts
+++ b/player/core/build.gradle.kts
@@ -36,8 +36,8 @@ ktlint {
 }
 
 dependencies {
-    implementation(project(":data"))
-    implementation(project(":preferences"))
+    implementation(projects.data)
+    implementation(projects.preferences)
     implementation(libs.androidx.core)
     implementation(libs.androidx.preference)
     implementation(libs.jellyfin.core)

--- a/player/video/build.gradle.kts
+++ b/player/video/build.gradle.kts
@@ -38,9 +38,9 @@ ktlint {
 }
 
 dependencies {
-    implementation(project(":player:core"))
-    implementation(project(":data"))
-    implementation(project(":preferences"))
+    implementation(projects.player.core)
+    implementation(projects.data)
+    implementation(projects.preferences)
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.lifecycle.viewmodel)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include(":app:phone")
 include(":app:tv")
 include(":core")


### PR DESCRIPTION
Use type-safe project accessors ([introduced in Gradle 7](https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors))