### PR TITLE
fix: media folders are invisible on 10.9.0

### DIFF
--- a/data/src/main/java/dev/jdtech/jellyfin/models/CollectionType.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/models/CollectionType.kt
@@ -27,7 +27,7 @@ enum class CollectionType(val type: String) {
             }
 
             return try {
-                entries.first { it.type == string }
+                entries.first { it.type == string.lowercase() }
             } catch (e: NoSuchElementException) {
                 defaultValue
             }


### PR DESCRIPTION
Seems to be the issue originated with the migration of CollectionType to enums from upstream ([#9764](https://github.com/jellyfin/jellyfin/pull/9764) & [#10702](https://github.com/jellyfin/jellyfin/pull/10702))

Lowercasing it was enough. 

Draft since 10.9.0 isn't stable yet, but i don't think merging this would cause any issue.