### PR TITLE
fix: library media item too small on pad when screen is portrait

### DIFF
--- a/core/src/main/res/values-w600dp/dimens.xml
+++ b/core/src/main/res/values-w600dp/dimens.xml
@@ -3,6 +3,6 @@
     <dimen name="setup_container_width">400dp</dimen>
     <item name="server_columns" type="integer">6</item>
     <item name="collection_columns" type="integer">3</item>
-    <item name="library_columns" type="integer">4</item>
+    <item name="library_columns" type="integer">3</item>
     <dimen name="person_detail_overview_height">124dp</dimen>
 </resources>

--- a/core/src/main/res/values-w720dp/dimens.xml
+++ b/core/src/main/res/values-w720dp/dimens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="server_columns" type="integer">8</item>
-    <item name="library_columns" type="integer">6</item>
+    <item name="library_columns" type="integer">4</item>
     <dimen name="person_detail_overview_height">200dp</dimen>
 </resources>

--- a/core/src/main/res/values-w840dp/dimens.xml
+++ b/core/src/main/res/values-w840dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="library_columns" type="integer">6</item>
+</resources>


### PR DESCRIPTION
The library span count is too small on pad when screen is portrait, so reduce w600dp and w720dp span count, and add w840dp span count.

See: https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes