### PR TITLE
Settings navigation fixes

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
@@ -92,7 +92,20 @@ class MainActivity : AppCompatActivity() {
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
             binding.navView.visibility = when (destination.id) {
-                R.id.twoPaneSettingsFragment, R.id.serverSelectFragment, R.id.addServerFragment, R.id.loginFragment, com.mikepenz.aboutlibraries.R.id.about_libraries_dest, R.id.usersFragment, R.id.serverAddressesFragment -> View.GONE
+                R.id.twoPaneSettingsFragment,
+                R.id.serverSelectFragment,
+                R.id.addServerFragment,
+                R.id.loginFragment,
+                com.mikepenz.aboutlibraries.R.id.about_libraries_dest,
+                R.id.usersFragment,
+                R.id.serverAddressesFragment,
+                R.id.settingsCacheFragment,
+                R.id.settingsNetworkFragment,
+                R.id.settingsDeviceFragment,
+                R.id.settingsPlayerFragment,
+                R.id.settingsDownloadsFragment,
+                R.id.settingsAppearanceFragment,
+                R.id.settingsLanguageFragment -> View.GONE
                 else -> View.VISIBLE
             }
             if (destination.id == com.mikepenz.aboutlibraries.R.id.about_libraries_dest) {

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/SettingsFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/SettingsFragment.kt
@@ -20,6 +20,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(CoreR.xml.fragment_settings, rootKey)
 
+        findPreference<Preference>("language")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsLanguageFragment())
+            true
+        }
+
         findPreference<Preference>("switchServer")?.setOnPreferenceClickListener {
             findNavController().navigate(TwoPaneSettingsFragmentDirections.actionNavigationSettingsToServerSelectFragment())
             true
@@ -34,6 +39,36 @@ class SettingsFragment : PreferenceFragmentCompat() {
         findPreference<Preference>("switchAddress")?.setOnPreferenceClickListener {
             val serverId = appPreferences.currentServer!!
             findNavController().navigate(TwoPaneSettingsFragmentDirections.actionNavigationSettingsToServerAddressesFragment(serverId))
+            true
+        }
+
+        findPreference<Preference>("appearance")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsAppearanceFragment())
+            true
+        }
+
+        findPreference<Preference>("downloads")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsDownloadsFragment())
+            true
+        }
+
+        findPreference<Preference>("player")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsPlayerFragment())
+            true
+        }
+
+        findPreference<Preference>("device")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsDeviceFragment())
+            true
+        }
+
+        findPreference<Preference>("network")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsNetworkFragment())
+            true
+        }
+
+        findPreference<Preference>("cache")?.setOnPreferenceClickListener {
+            findNavController().navigate(TwoPaneSettingsFragmentDirections.actionTwoPaneSettingsFragmentToSettingsCacheFragment())
             true
         }
 

--- a/app/phone/src/main/res/navigation/app_navigation.xml
+++ b/app/phone/src/main/res/navigation/app_navigation.xml
@@ -6,6 +6,34 @@
     app:startDestination="@+id/homeFragment">
 
     <fragment
+        android:id="@+id/settingsDeviceFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsDeviceFragment"
+        android:label="@string/settings_category_device" />
+    <fragment
+        android:id="@+id/settingsCacheFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsCacheFragment"
+        android:label="@string/settings_category_cache" />
+    <fragment
+        android:id="@+id/settingsDownloadsFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsDownloadsFragment"
+        android:label="@string/settings_category_download" />
+    <fragment
+        android:id="@+id/settingsLanguageFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsLanguageFragment"
+        android:label="@string/settings_category_language" />
+    <fragment
+        android:id="@+id/settingsNetworkFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsNetworkFragment"
+        android:label="@string/settings_category_network" />
+    <fragment
+        android:id="@+id/settingsAppearanceFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsAppearanceFragment"
+        android:label="@string/settings_category_appearance" />
+    <fragment
+        android:id="@+id/settingsPlayerFragment"
+        android:name="dev.jdtech.jellyfin.fragments.SettingsPlayerFragment"
+        android:label="@string/settings_category_player" />
+    <fragment
         android:id="@+id/homeFragment"
         android:name="dev.jdtech.jellyfin.fragments.HomeFragment"
         android:label="@string/title_home"
@@ -74,16 +102,81 @@
         android:label="@string/title_settings">
         <action
             android:id="@+id/action_navigation_settings_to_serverSelectFragment"
-            app:destination="@id/serverSelectFragment" />
+            app:destination="@id/serverSelectFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
         <action
             android:id="@+id/action_navigation_settings_to_usersFragment"
-            app:destination="@id/usersFragment" />
+            app:destination="@id/usersFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
         <action
             android:id="@+id/action_navigation_settings_to_serverAddressesFragment"
-            app:destination="@id/serverAddressesFragment" />
+            app:destination="@id/serverAddressesFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
         <action
             android:id="@+id/action_settingsFragment_to_about_libraries"
-            app:destination="@id/about_libraries" />
+            app:destination="@id/about_libraries"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
+        <action
+            android:id="@+id/action_TwoPaneSettingsFragmentToSettingsDownloadsFragment"
+            app:destination="@id/settingsDownloadsFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+        <action
+            android:id="@+id/action_twoPaneSettingsFragment_to_settingsDeviceFragment"
+            app:destination="@id/settingsDeviceFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+        <action
+            android:id="@+id/action_twoPaneSettingsFragment_to_settingsLanguageFragment"
+            app:destination="@id/settingsLanguageFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+        <action
+            android:id="@+id/action_twoPaneSettingsFragment_to_settingsNetworkFragment"
+            app:destination="@id/settingsNetworkFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+        <action
+            android:id="@+id/action_twoPaneSettingsFragment_to_settingsAppearanceFragment"
+            app:destination="@id/settingsAppearanceFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+        <action
+            android:id="@+id/action_twoPaneSettingsFragment_to_settingsCacheFragment"
+            app:destination="@id/settingsCacheFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
+        <action
+            android:id="@+id/action_twoPaneSettingsFragment_to_settingsPlayerFragment"
+            app:destination="@id/settingsPlayerFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
     </fragment>
     <fragment
         android:id="@+id/settingsFragment"

--- a/core/src/main/res/xml/fragment_settings.xml
+++ b/core/src/main/res/xml/fragment_settings.xml
@@ -47,7 +47,9 @@
         app:key="network"
         app:title="@string/settings_category_network" />
 
-    <Preference app:title="@string/settings_category_cache" />
+    <Preference
+        app:key="cache"
+        app:title="@string/settings_category_cache" />
 
     <SwitchPreferenceCompat
         android:defaultValue="false"

--- a/core/src/main/res/xml/fragment_settings.xml
+++ b/core/src/main/res/xml/fragment_settings.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsLanguageFragment"
-        app:title="@string/settings_category_language"
-        app:icon="@drawable/ic_languages"/>
+        app:icon="@drawable/ic_languages"
+        app:key="language"
+        app:title="@string/settings_category_language" />
 
     <Preference
         app:icon="@drawable/ic_server"
@@ -23,33 +23,31 @@
         app:title="@string/addresses" />
 
     <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsAppearanceFragment"
         app:icon="@drawable/ic_palette"
+        app:key="appearance"
         app:title="@string/settings_category_appearance" />
 
     <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsDownloadsFragment"
         app:icon="@drawable/ic_download"
-        app:title="@string/settings_category_download"/>
+        app:key="downloads"
+        app:title="@string/settings_category_download" />
 
     <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsPlayerFragment"
         app:icon="@drawable/ic_play"
+        app:key="player"
         app:title="@string/settings_category_player" />
 
     <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsDeviceFragment"
-        app:title="@string/settings_category_device"
-        app:icon="@drawable/ic_smartphone" />
+        app:icon="@drawable/ic_smartphone"
+        app:key="device"
+        app:title="@string/settings_category_device" />
 
     <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsNetworkFragment"
-        app:title="@string/settings_category_network"
-        app:icon="@drawable/ic_network"/>
+        app:icon="@drawable/ic_network"
+        app:key="network"
+        app:title="@string/settings_category_network" />
 
-    <Preference
-        app:fragment="dev.jdtech.jellyfin.fragments.SettingsCacheFragment"
-        app:title="@string/settings_category_cache" />
+    <Preference app:title="@string/settings_category_cache" />
 
     <SwitchPreferenceCompat
         android:defaultValue="false"

--- a/core/src/main/res/xml/fragment_settings_language.xml
+++ b/core/src/main/res/xml/fragment_settings_language.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
     <Preference
         app:icon="@drawable/ic_languages"
         app:isPreferenceVisible="false"

--- a/core/src/main/res/xml/fragment_settings_language.xml
+++ b/core/src/main/res/xml/fragment_settings_language.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
-
     <Preference
         app:icon="@drawable/ic_languages"
         app:isPreferenceVisible="false"


### PR DESCRIPTION
The pr addresses all settings sub menus except "Servers", "Users" and "Addresses" (Because they are already working as expected).
Changes for all the other sub menus:
- Entering and exit animations are now consistent across all side menus.
- Pressing the back button in the header returns to the main settings menus instead of returning to home.
- Header label now correctly states the sub menu name instead of just saying "Settings"

P.S. Previously the animations for the changed sub menus were "slide in/out" whereas now they're "fade in/out". Not sure if this is better, maybe I should change them all to be "slide in/out"?