### PR TITLE
feat: add support for "homevideos" collections

### DIFF
--- a/data/src/main/java/dev/jdtech/jellyfin/models/CollectionType.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/models/CollectionType.kt
@@ -21,6 +21,7 @@ enum class CollectionType(val type: String) {
             TvShows,
             BoxSets,
             Mixed,
+            HomeVideos
         )
 
         fun fromString(string: String?): CollectionType {

--- a/data/src/main/java/dev/jdtech/jellyfin/models/FindroidItem.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/models/FindroidItem.kt
@@ -28,7 +28,7 @@ suspend fun BaseItemDto.toFindroidItem(
     serverDatabase: ServerDatabaseDao? = null,
 ): FindroidItem? {
     return when (type) {
-        BaseItemKind.MOVIE -> toFindroidMovie(jellyfinRepository, serverDatabase)
+        BaseItemKind.MOVIE, BaseItemKind.VIDEO -> toFindroidMovie(jellyfinRepository, serverDatabase)
         BaseItemKind.EPISODE -> toFindroidEpisode(jellyfinRepository)
         BaseItemKind.SEASON -> toFindroidSeason(jellyfinRepository)
         BaseItemKind.SERIES -> toFindroidShow(jellyfinRepository)


### PR DESCRIPTION
`homevideos` collections is for libraries created with `Photos` type which is for unorganized folders

![image](https://github.com/jarnedemeulemeester/findroid/assets/65506006/204d8660-cf50-4022-bc98-c6174c924875)
