### PR TITLE
Automatically connect to reachable address on app launch

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
@@ -2,6 +2,7 @@ package dev.jdtech.jellyfin
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
@@ -70,6 +71,11 @@ class MainActivity : AppCompatActivity() {
         if (appPreferences.offlineMode) {
             navView.menu.clear()
             navView.inflateMenu(CoreR.menu.bottom_nav_menu_offline)
+        }
+
+        viewModel.addressChangedOnBoot.observe(this) {
+            val serverName = appPreferences.currentServer?.let { id -> database.getServerCurrentAddress(id)?.address }
+            Toast.makeText(applicationContext, applicationContext.getString(CoreR.string.connected_to_server, serverName), Toast.LENGTH_SHORT).show()
         }
 
         setSupportActionBar(binding.mainToolbar)

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/ServerAddressesFragment.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/fragments/ServerAddressesFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -20,6 +21,7 @@ import dev.jdtech.jellyfin.viewmodels.ServerAddressesEvent
 import dev.jdtech.jellyfin.viewmodels.ServerAddressesViewModel
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import dev.jdtech.jellyfin.core.R as CoreR
 
 @AndroidEntryPoint
 class ServerAddressesFragment : Fragment() {
@@ -39,6 +41,7 @@ class ServerAddressesFragment : Fragment() {
             ServerAddressAdapter(
                 { address ->
                     viewModel.switchToAddress(address)
+                    Toast.makeText(context, requireContext().getString(CoreR.string.connected_to_server, address.address), Toast.LENGTH_SHORT).show()
                 },
                 { address ->
                     DeleteServerAddressDialog(viewModel, address).show(

--- a/core/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
@@ -56,8 +56,12 @@ constructor(
                                 try {
                                     Timber.e("checking ${addressData.address}")
                                     val hostname = addressData.address.removePrefix("https://").removePrefix("http://").split(':')[0].split('/')[0]
-                                    if (InetAddress.getByName(hostname).isReachable(appPreferences.connectTimeout.toInt())) addressData
-                                    else null
+                                    if (InetAddress.getByName(hostname).isReachable(1000)){
+                                        addressData
+                                    }
+                                    else {
+                                        null
+                                    }
                                 } catch (e: UnknownHostException) {
                                     null
                                 }

--- a/core/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
@@ -1,15 +1,24 @@
 package dev.jdtech.jellyfin.viewmodels
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.jdtech.jellyfin.AppPreferences
 import dev.jdtech.jellyfin.database.ServerDatabaseDao
 import dev.jdtech.jellyfin.models.Server
+import dev.jdtech.jellyfin.models.ServerAddress
 import dev.jdtech.jellyfin.models.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import timber.log.Timber
+import java.net.InetAddress
+import java.net.UnknownHostException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,6 +32,9 @@ constructor(
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState = _uiState.asStateFlow()
+
+    private var _addressChangedOnBoot = MutableLiveData<Boolean>()
+    val addressChangedOnBoot: LiveData<Boolean> = _addressChangedOnBoot
 
     sealed class UiState {
         data class Normal(val server: Server?, val user: User?) : UiState()
@@ -38,6 +50,44 @@ constructor(
             val serverId = appPreferences.currentServer
             serverId?.let { id ->
                 database.getServerWithAddressAndUser(id)?.let { data ->
+                    database.getServerWithAddresses(id).let { dataAddresses ->
+                        val bestAddressDeferred = dataAddresses.addresses.map { addressData ->
+                            async(Dispatchers.IO) {
+                                try {
+                                    Timber.e("checking ${addressData.address}")
+                                    val hostname = addressData.address.removePrefix("https://").removePrefix("http://").split(':')[0].split('/')[0]
+                                    if (InetAddress.getByName(hostname).isReachable(appPreferences.connectTimeout.toInt())) addressData
+                                    else null
+                                } catch (e: UnknownHostException) {
+                                    null
+                                }
+                            }
+                        }
+
+                        var bestAddress: ServerAddress? = null
+
+                        runBlocking {
+                            for (address in bestAddressDeferred) {
+                                val result = address.await()
+                                if (result != null) {
+                                    bestAddress = result
+                                }
+                            }
+                        }
+
+                        val server = database.get(serverId)
+                        if (bestAddress != null) {
+                            Timber.i("${bestAddress!!.address} is the best address")
+                            if (server?.currentServerAddressId != bestAddress!!.id) {
+                                _addressChangedOnBoot.postValue(true)
+                                server?.currentServerAddressId = bestAddress!!.id
+                                database.update(server!!)
+                            }
+                        } else {
+                            Timber.i("No viable addresses found")
+                        }
+                    }
+
                     _uiState.emit(
                         UiState.Normal(data.server, data.user),
                     )

--- a/core/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/viewmodels/MainViewModel.kt
@@ -56,10 +56,9 @@ constructor(
                                 try {
                                     Timber.e("checking ${addressData.address}")
                                     val hostname = addressData.address.removePrefix("https://").removePrefix("http://").split(':')[0].split('/')[0]
-                                    if (InetAddress.getByName(hostname).isReachable(1000)){
+                                    if (InetAddress.getByName(hostname).isReachable(1000)) {
                                         addressData
-                                    }
-                                    else {
+                                    } else {
                                         null
                                     }
                                 } catch (e: UnknownHostException) {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="addresses">Addresses</string>
     <string name="add_address">Add address</string>
     <string name="add_server_address">Add server address</string>
+    <string name="connected_to_server">Connected to server:\n%1$s</string>
     <string name="add">Add</string>
     <string name="quick_connect">Quick Connect</string>
     <string name="picture_in_picture">Picture-in-picture</string>


### PR DESCRIPTION
I'm gonna be honest. This may just be the most disgusting piece of code I've written. There's:
- Code duplication.
- Unforeseen consequences (The app will not leave the loading screen if all addresses are unreachable and I'm sure there are many more).
- General ugliness.

What (I think) the pr does is it pings all registered server addresses and connects to the one with the fastest response, so it saves a couple of clicks if you often use something like Tailscale to access the app from outside the local network.

If I know it's bad, why am I still creating this PR?
I... I didn't think about that actually.
Honestly I just hope to get some guidance on how to do this better as I am a total android development newbie. I hope I don't sound like a troll though :P