### PR TITLE
Fix wrong "Date Played" sort for TV shows

### DIFF
--- a/core/src/main/java/dev/jdtech/jellyfin/dialogs/SortDialogFragment.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/dialogs/SortDialogFragment.kt
@@ -51,7 +51,12 @@ class SortDialogFragment(
                             sortByOptions,
                             currentSortBy.ordinal,
                         ) { dialog, which ->
-                            val sortBy = sortByValues[which]
+                            val sortBy =
+                                if (libraryType == CollectionType.TvShows && sortByValues[which] == SortBy.DATE_PLAYED) {
+                                    SortBy.SERIES_DATE_PLAYED
+                                } else {
+                                    sortByValues[which]
+                                }
                             appPreferences.sortBy = sortBy.name
                             viewModel.loadItems(
                                 parentId,

--- a/data/src/main/java/dev/jdtech/jellyfin/models/SortBy.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/models/SortBy.kt
@@ -7,6 +7,7 @@ enum class SortBy(val sortString: String) {
     DATE_ADDED("DateCreated"),
     DATE_PLAYED("DatePlayed"),
     RELEASE_DATE("PremiereDate"),
+    SERIES_DATE_PLAYED("SeriesDatePlayed")
     ;
 
     companion object {


### PR DESCRIPTION
For series content, Jellyfin uses "[SeriesDatePlayed](https://github.com/jellyfin/jellyfin/blob/2cbef3aa383b05e51b76fb399a2a2fded56518e5/Jellyfin.Data/Enums/ItemSortBy.cs#L146)" to sort by last played rather than the current "DatePlayed".

Tested it, and I'm getting the same sort result in findroid and jellyfin with this change, but I'm not sure the best way to do this change. I was going to create a separate enum, but this is the only sort property that has has this issue.