### PR TITLE
TV playback controls: add fast seeking and enable track selection without pausing

### DIFF
--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
@@ -260,8 +260,6 @@ fun VideoPlayerControls(
             ) {
                 VideoPlayerMediaButton(
                     icon = painterResource(id = R.drawable.ic_speaker),
-                    state = state,
-                    isPlaying = isPlaying,
                     onClick = {
                         val tracks = getTracks(player, C.TRACK_TYPE_AUDIO)
                         navigator.navigate(VideoPlayerTrackSelectorDialogDestination(C.TRACK_TYPE_AUDIO, tracks))
@@ -269,8 +267,6 @@ fun VideoPlayerControls(
                 )
                 VideoPlayerMediaButton(
                     icon = painterResource(id = R.drawable.ic_closed_caption),
-                    state = state,
-                    isPlaying = isPlaying,
                     onClick = {
                         val tracks = getTracks(player, C.TRACK_TYPE_TEXT)
                         navigator.navigate(VideoPlayerTrackSelectorDialogDestination(C.TRACK_TYPE_TEXT, tracks))

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
@@ -107,13 +107,24 @@ fun PlayerScreen(
         mutableLongStateOf(0L)
     }
     var isPlaying by remember {
-        mutableStateOf(viewModel.player.isPlaying)
+        mutableStateOf(true)
+    }
+    val onPause = {
+        viewModel.player.pause()
+        isPlaying = false
+    }
+    val onPlayPauseToggle = {
+        if (isPlaying)
+            onPause()
+        else {
+            viewModel.player.play()
+            isPlaying = true
+        }
     }
     LaunchedEffect(Unit) {
         while (true) {
             delay(300)
             currentPosition = viewModel.player.currentPosition
-            isPlaying = viewModel.player.isPlaying
         }
     }
 
@@ -147,6 +158,7 @@ fun PlayerScreen(
         modifier = Modifier
             .dPadEvents(
                 exoPlayer = viewModel.player,
+                onPause = onPause,
                 videoPlayerState = videoPlayerState,
             )
             .focusable(),
@@ -195,6 +207,7 @@ fun PlayerScreen(
                     contentCurrentPosition = currentPosition,
                     player = viewModel.player,
                     state = videoPlayerState,
+                    onPlayPauseToggle = onPlayPauseToggle,
                     focusRequester = focusRequester,
                     navigator = navigator,
                 )
@@ -211,16 +224,10 @@ fun VideoPlayerControls(
     contentCurrentPosition: Long,
     player: Player,
     state: VideoPlayerState,
+    onPlayPauseToggle: () -> Unit,
     focusRequester: FocusRequester,
     navigator: DestinationsNavigator,
 ) {
-    val onPlayPauseToggle = { shouldPlay: Boolean ->
-        if (shouldPlay) {
-            player.play()
-        } else {
-            player.pause()
-        }
-    }
 
     VideoPlayerControlsLayout(
         mediaTitle = {
@@ -269,6 +276,7 @@ fun VideoPlayerControls(
 
 private fun Modifier.dPadEvents(
     exoPlayer: Player,
+    onPause: () -> Unit,
     videoPlayerState: VideoPlayerState,
 ): Modifier = this.handleDPadKeyEvents(
     onLeft = {},
@@ -276,7 +284,7 @@ private fun Modifier.dPadEvents(
     onUp = {},
     onDown = {},
     onEnter = {
-        exoPlayer.pause()
+        onPause()
         videoPlayerState.showControls()
     },
 )

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
@@ -188,7 +188,6 @@ fun PlayerScreen(
                 when (lifecycle) {
                     Lifecycle.Event.ON_PAUSE -> {
                         it.onPause()
-                        it.player?.pause()
                     }
 
                     Lifecycle.Event.ON_RESUME -> {

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.viewinterop.AndroidView
@@ -154,14 +155,20 @@ fun PlayerScreen(
         }
     }
 
+
+    var isFocused by remember { mutableStateOf(true) }
     Box(
         modifier = Modifier
+            .onFocusChanged {
+                isFocused = it.isFocused
+            }
             .dPadEvents(
+                isFocused = isFocused,
                 exoPlayer = viewModel.player,
                 onPause = onPause,
                 videoPlayerState = videoPlayerState,
             )
-            .focusable(),
+            .focusable()
     ) {
         AndroidView(
             factory = { context ->
@@ -275,19 +282,32 @@ fun VideoPlayerControls(
 }
 
 private fun Modifier.dPadEvents(
+    isFocused: Boolean,
     exoPlayer: Player,
     onPause: () -> Unit,
     videoPlayerState: VideoPlayerState,
-): Modifier = this.handleDPadKeyEvents(
-    onLeft = {},
-    onRight = {},
-    onUp = {},
-    onDown = {},
-    onEnter = {
-        onPause()
-        videoPlayerState.showControls()
-    },
-)
+): Modifier =
+    this.handleDPadKeyEvents(
+        onLeft = {
+            if (isFocused) {
+                exoPlayer.seekBack()
+            }
+        },
+        onRight = {
+            if (isFocused) {
+                exoPlayer.seekForward()
+            }
+        },
+        onUp = {},
+        onDown = {},
+        onEnter = {
+            if (isFocused) {
+                onPause()
+                videoPlayerState.showControls()
+            }
+
+        },
+    )
 
 @androidx.annotation.OptIn(UnstableApi::class)
 private fun getTracks(player: Player, type: Int): Array<Track> {

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/PlayerScreen.kt
@@ -298,14 +298,17 @@ private fun Modifier.dPadEvents(
                 exoPlayer.seekForward()
             }
         },
-        onUp = {},
+        onUp = {
+            if (isFocused) {
+                videoPlayerState.showControls()
+            }
+        },
         onDown = {},
         onEnter = {
             if (isFocused) {
                 onPause()
                 videoPlayerState.showControls()
             }
-
         },
     )
 

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerMediaButton.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerMediaButton.kt
@@ -13,18 +13,9 @@ import androidx.tv.material3.IconButton
 @Composable
 fun VideoPlayerMediaButton(
     icon: Painter,
-    state: VideoPlayerState,
-    isPlaying: Boolean,
     onClick: () -> Unit = {},
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    val isFocused by interactionSource.collectIsFocusedAsState()
-
-    LaunchedEffect(isFocused && isPlaying) {
-        if (isFocused && isPlaying) {
-            state.showControls()
-        }
-    }
 
     IconButton(onClick = onClick, interactionSource = interactionSource) {
         Icon(painter = icon, contentDescription = null)

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerSeekBar.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerSeekBar.kt
@@ -33,6 +33,7 @@ import dev.jdtech.jellyfin.utils.handleDPadKeyEvents
 @Composable
 fun VideoPlayerSeekBar(
     progress: Float,
+    onPause: () -> Unit,
     onSeek: (seekProgress: Float) -> Unit,
     state: VideoPlayerState,
 ) {
@@ -69,6 +70,7 @@ fun VideoPlayerSeekBar(
                         onSeek(seekProgress)
                         focusManager.moveFocus(FocusDirection.Exit)
                     } else {
+                        onPause()
                         seekProgress = progress
                     }
                     isSelected = !isSelected
@@ -125,6 +127,7 @@ fun VideoPlayerSeekBarPreview() {
     FindroidTheme {
         VideoPlayerSeekBar(
             progress = 0.4f,
+            onPause = {},
             onSeek = {},
             state = rememberVideoPlayerState(),
         )

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerSeeker.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerSeeker.kt
@@ -51,6 +51,10 @@ fun VideoPlayerSeeker(
             }
         }
 
+    val onPause =
+        { if (isPlaying) onPlayPauseToggle() }
+
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -92,6 +96,7 @@ fun VideoPlayerSeeker(
             Spacer(modifier = Modifier.height(MaterialTheme.spacings.small))
             VideoPlayerSeekBar(
                 progress = (contentProgress / contentDuration).toFloat(),
+                onPause = onPause,
                 onSeek = onSeek,
                 state = state,
             )

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerSeeker.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/ui/components/player/VideoPlayerSeeker.kt
@@ -29,7 +29,7 @@ fun VideoPlayerSeeker(
     focusRequester: FocusRequester,
     state: VideoPlayerState,
     isPlaying: Boolean,
-    onPlayPauseToggle: (Boolean) -> Unit,
+    onPlayPauseToggle: () -> Unit,
     onSeek: (Float) -> Unit,
     contentProgress: Duration,
     contentDuration: Duration,
@@ -56,7 +56,7 @@ fun VideoPlayerSeeker(
     ) {
         IconButton(
             onClick = {
-                onPlayPauseToggle(!isPlaying)
+                onPlayPauseToggle()
             },
             modifier = Modifier.focusRequester(focusRequester),
         ) {


### PR DESCRIPTION
Hi @jarnedemeulemeester thanks a lot for your work ! I am using the Android TV version of Findroid because the playback is much more robust than the official one. But I found the controls to be a bit finicky... here is a proposition to improve them a bit, adding the possibility of fast seeking and track switching without pause. I hope this is of interest to you ! It is my first time using Compose so I would be happy to receive feedback and improve my code.

This PR proposes an addition to the current playback controls to allow seeking and changing tracks without pausing the playback. 

The current controls are especially tedious to use for seeking:

1. First press the <kbd>Enter</kbd> key to pause to show the controls. This also pauses the playback.
2. Navigate to the seeker (right then bottom).
3. Activate seeking by pressing <kbd>Enter</kbd>.
4. Seek by pressing multiple times <kbd>Right</kbd>  or <kbd>Left</kbd>.
5. Validate by pressing <kbd>Enter</kbd>.
7. Press <kbd>Enter</kbd> to resume the playback.

This PR adds two new behaviors:

1. Fast-seeking by pressing <kbd>Right</kbd> or <kbd>Left</kbd>  keys during playback while the controls are not shown.
2. During, playback, pressing the <kbd>Up</kbd>  shows the controls _without pausing the playback_ which allows changing the audio or subtitle tracks without pausing. 

However, I had to inhibit several current behaviors to achieve that:
- When seeking, the player state briefly switches to `paused`  while buffering. But this is not a pause to which the UI should react. In commit dc1aac3d6733b01b9407cc63a470fedd43b2a3dc I make UI pause-state independent from the player's own state so that we can have finer behaviors.
- The `Box` containing the video surface has custom bindings for the D-pad keys: on <kbd>Enter</kbd> it pauses playback and shows the controls. These actions were still performed while the controls were shown (without a negative impact). In commit a8461c1914b383669f9124cf5dab2a99a42cbfc5 I restrict these actions to trigger only if the player box is in focus. This prevent fast-seek on <kbd>Right</kbd> and <kbd>Left</kbd> to trigger while navigating in the controls.
-  Opening a track selection dialog pauses the player's activity which used to pause the playback. In c30bc52e447b1c229c7f92c7a8422f109d9dd898 I disable that behavior to allow track switching without pausing.