### PR TITLE
settings compile errors: remove tint from drawables

### DIFF
--- a/settings/src/main/res/drawable/ic_closed_caption.xml
+++ b/settings/src/main/res/drawable/ic_closed_caption.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.9,-2 -2,-2zM19,18L5,18L5,6h14v12zM7,15h3c0.55,0 1,-0.45 1,-1v-1L9.5,13v0.5h-2v-3h2v0.5L11,11v-1c0,-0.55 -0.45,-1 -1,-1L7,9c-0.55,0 -1,0.45 -1,1v4c0,0.55 0.45,1 1,1zM14,15h3c0.55,0 1,-0.45 1,-1v-1h-1.5v0.5h-2v-3h2v0.5L18,11v-1c0,-0.55 -0.45,-1 -1,-1h-3c-0.55,0 -1,0.45 -1,1v4c0,0.55 0.45,1 1,1z"
       android:fillColor="@android:color/white"/>

--- a/settings/src/main/res/drawable/ic_download.xml
+++ b/settings/src/main/res/drawable/ic_download.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M21,15v4a2,2 0,0 1,-2 2H5a2,2 0,0 1,-2 -2v-4"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_hard_drive.xml
+++ b/settings/src/main/res/drawable/ic_hard_drive.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M22,12L2,12"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_info.xml
+++ b/settings/src/main/res/drawable/ic_info.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_languages.xml
+++ b/settings/src/main/res/drawable/ic_languages.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M5,8l6,6"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_network.xml
+++ b/settings/src/main/res/drawable/ic_network.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M9,2h6v6h-6z"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_palette.xml
+++ b/settings/src/main/res/drawable/ic_palette.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M13.5,6.5m-0.5,0a0.5,0.5 0,1 1,1 0a0.5,0.5 0,1 1,-1 0"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_play.xml
+++ b/settings/src/main/res/drawable/ic_play.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M5,3l14,9l-14,9l0,-18z"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_server.xml
+++ b/settings/src/main/res/drawable/ic_server.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M4,2L20,2A2,2 0,0 1,22 4L22,8A2,2 0,0 1,20 10L4,10A2,2 0,0 1,2 8L2,4A2,2 0,0 1,4 2z"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_server_off.xml
+++ b/settings/src/main/res/drawable/ic_server_off.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M7,2h13a2,2 0,0 1,2 2v4a2,2 0,0 1,-2 2h-5"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_speaker.xml
+++ b/settings/src/main/res/drawable/ic_speaker.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M6,2L18,2A2,2 0,0 1,20 4L20,20A2,2 0,0 1,18 22L6,22A2,2 0,0 1,4 20L4,4A2,2 0,0 1,6 2z"
       android:strokeLineJoin="round"

--- a/settings/src/main/res/drawable/ic_user.xml
+++ b/settings/src/main/res/drawable/ic_user.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:pathData="M20,21v-2a4,4 0,0 0,-4 -4H8a4,4 0,0 0,-4 4v2"
       android:strokeLineJoin="round"


### PR DESCRIPTION
The colorControlNormal attribute could not be resolved and was causing build failures when selecting "Compile all sources" in Android Studio or "gradlew build" from the command line.  The colorControlNormal attribute is resolved in the Android theme, but the settings submodule did not have any theme, so it could not be resolved.

The tint is applied by Jetpack Compose Icon, so it's not needed in the drawable XML anymore.

Note: You could remove all of the settings drawables and replace them with ImageVectors.  However I found it to be difficult to map all of the current drawables to the Material Icons (you may need the extended icons).  If this is desirable, you may need to compromise with a different icon that has the same meaning.