### PR TITLE
fix(player): hide trickplay scrubber when displaying chapter

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -179,6 +179,7 @@ class PlayerGestureHelper(
     }
 
     private fun displayChapter(chapter: PlayerChapter) {
+        activity.binding.progressScrubberTrickplay.visibility = View.GONE
         activity.binding.progressScrubberLayout.visibility = View.VISIBLE
         activity.binding.progressScrubberText.text = chapter.name ?: ""
     }


### PR DESCRIPTION
Hides the trickplay scrubber view when scrubbing through chapters.

fix #947