### PR TITLE
fix(player): do not set brightness when exiting PiP mode if V/B gestures are disabled

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -450,15 +450,17 @@ class PlayerActivity : BasePlayerActivity() {
 
                 // Override auto brightness
                 window.attributes = window.attributes.apply {
-                    screenBrightness =
-                        if (appPreferences.getValue(appPreferences.playerGesturesBrightnessRemember)) {
-                            appPreferences.getValue(appPreferences.playerBrightness)
-                        } else {
-                            Settings.System.getInt(
-                                contentResolver,
-                                Settings.System.SCREEN_BRIGHTNESS,
-                            ).toFloat() / 255
-                        }
+                    if (appPreferences.getValue(appPreferences.playerGesturesVB)) {
+                        screenBrightness =
+                            if (appPreferences.getValue(appPreferences.playerGesturesBrightnessRemember)) {
+                                appPreferences.getValue(appPreferences.playerBrightness)
+                            } else {
+                                Settings.System.getInt(
+                                    contentResolver,
+                                    Settings.System.SCREEN_BRIGHTNESS,
+                                ).toFloat() / 255
+                            }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Do not set brightness when exiting PiP mode if V/B gestures are disabled

May fix #1029