### PR TITLE
docs: fix discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ I am developing this application in my spare time.
 [JDTech Weblate](https://weblate.jdtech.dev) is a self-hosted instance of Weblate where you can translate this project and future projects of mine.
 
 ## Questions?
-We have a Discord server to discuss future development or ask general questions.
-https://discord.gg/tg5VvTFwTV
+We have a [Discord server](https://discord.gg/tg5VvTFwTV) to discuss future development or ask general questions.
 
 ## License
 This project is licensed under [GPLv3](LICENSE).


### PR DESCRIPTION
Not fully sure what this was supposed to do but the vercel deployment doesnt exist anymore so the invite link was no longer visible

<img width="714" height="124" alt="image" src="https://github.com/user-attachments/assets/3930e602-5920-4889-810a-ab172c85782a" />
