### PR TITLE
fix(player): handle MPV seek rounding to prevent intro skip loops

### DIFF
--- a/player/local/src/main/java/dev/jdtech/jellyfin/player/local/presentation/PlayerViewModel.kt
+++ b/player/local/src/main/java/dev/jdtech/jellyfin/player/local/presentation/PlayerViewModel.kt
@@ -542,7 +542,7 @@ constructor(
         } else {
             player.seekTo(
                 if (appPreferences.getValue(appPreferences.playerMpv)) {
-                    // MPV uses seconds so approximate to next second to avoid loop
+                    // MPV uses seconds, so round up to the next second boundary to avoid loop
                     val roundingBase = 1000L
                     (segment.endTicks + roundingBase - 1) / roundingBase * roundingBase
                 } else {


### PR DESCRIPTION
This commit adjusts the seek logic when skipping segments to prevent a potential infinite loop when the MPV player is used. Since MPV uses seconds for seeking, the `endTicks` value is now rounded up to the next second to ensure the player moves past the skip trigger point.

fix #1123