### PR TITLE
Add ability to play next episode across the next season

### DIFF
--- a/player/local/src/main/java/dev/jdtech/jellyfin/player/local/domain/PlaylistManager.kt
+++ b/player/local/src/main/java/dev/jdtech/jellyfin/player/local/domain/PlaylistManager.kt
@@ -46,10 +46,11 @@ class PlaylistManager @Inject internal constructor(private val repository: Jelly
                 BaseItemKind.SERIES -> {
                     val nextUpEpisode = repository.getNextUp(itemId).firstOrNull()
 
-                    val episodes = when (nextUpEpisode){
-                        null -> getEpisodesBySeries(itemId)
-                        else -> getEpisodesByEpisode(nextUpEpisode)
-                    }
+                    val episodes =
+                        when (nextUpEpisode) {
+                            null -> getEpisodesBySeries(itemId)
+                            else -> getEpisodesByEpisode(nextUpEpisode)
+                        }
 
                     if (episodes.isEmpty()) {
                         return null
@@ -189,24 +190,29 @@ class PlaylistManager @Inject internal constructor(private val repository: Jelly
         return getEpisodes(currentSeason, nextSeason)
     }
 
-    private suspend fun getEpisodes(currentSeason: FindroidSeason, nextSeason: FindroidSeason?): List<FindroidEpisode> {
-        val currentSeasonEpisodes = repository
-            .getEpisodes(
-                seriesId = currentSeason.seriesId,
-                seasonId = currentSeason.id,
-                fields = listOf(ItemFields.CHAPTERS, ItemFields.TRICKPLAY),
-            )
-            .filter { !it.missing }
+    private suspend fun getEpisodes(
+        currentSeason: FindroidSeason,
+        nextSeason: FindroidSeason?,
+    ): List<FindroidEpisode> {
+        val currentSeasonEpisodes =
+            repository
+                .getEpisodes(
+                    seriesId = currentSeason.seriesId,
+                    seasonId = currentSeason.id,
+                    fields = listOf(ItemFields.CHAPTERS, ItemFields.TRICKPLAY),
+                )
+                .filter { !it.missing }
 
         if (nextSeason == null) return currentSeasonEpisodes
 
-        val nextSeasonEpisodes = repository
-            .getEpisodes(
-                seriesId = nextSeason.seriesId,
-                seasonId = nextSeason.id,
-                fields = listOf(ItemFields.CHAPTERS, ItemFields.TRICKPLAY),
-            )
-            .filter { !it.missing }
+        val nextSeasonEpisodes =
+            repository
+                .getEpisodes(
+                    seriesId = nextSeason.seriesId,
+                    seasonId = nextSeason.id,
+                    fields = listOf(ItemFields.CHAPTERS, ItemFields.TRICKPLAY),
+                )
+                .filter { !it.missing }
 
         val fullEpisodeList = currentSeasonEpisodes + nextSeasonEpisodes
         return fullEpisodeList


### PR DESCRIPTION
Adds the ability to use the "next item" button to play from the next season as well by expanding the playlist to contain the current and next season rather than simply the current one.

**Note:** If the user starts at i.e. season 1, they will be able to use the next button to start season 2. If they however keep playing through all of season 2 in the same session, they will be unable to start season 3. This is currently a compromise since it should be a somewhat rare occasion that someone goes through a full season in one sitting but it can happen.

I'm not entirely sure what the best solution for the current implementation would be, but in general I see 3 possible ways to go about this:
 - Rebuild the playlist to contain a next and a previous item every time an episode is started
 - Add all episodes of the series to the playlist all the time
 - Fetch the next item here (maybe season so we only do one fetch) https://github.com/jarnedemeulemeester/findroid/blob/490220a21043dbf86d23906403a75f2da1a0e8bc/player/local/src/main/java/dev/jdtech/jellyfin/player/local/domain/PlaylistManager.kt#L173-174


If any of the other solutions I mentioned are preferred, I can gladly swap out the implementation 

Fixes #535