### PR TITLE
feat(player): implement non-liear brightness sensitivity and decimal display

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -383,8 +383,13 @@ class PlayerGestureHelper(
                                         ) / 255
                                 }
                         }
+
+                        // Reach 100% sensitivity at 15% brightness and above
+                        val normalizedBrightness = (swipeGestureValueTrackerBrightness / 0.15f).coerceAtMost(1.0f)
+                        val sensitivityMultiplier = 0.10f + (0.90f * normalizedBrightness * normalizedBrightness)
+
                         swipeGestureValueTrackerBrightness =
-                            (swipeGestureValueTrackerBrightness + ratioChange).coerceIn(
+                            (swipeGestureValueTrackerBrightness + ratioChange * sensitivityMultiplier).coerceIn(
                                 brightnessRange
                             )
                         val lp = window.attributes
@@ -393,13 +398,12 @@ class PlayerGestureHelper(
 
                         activity.binding.gestureBrightnessLayout.visibility = View.VISIBLE
                         activity.binding.gestureBrightnessProgressBar.max =
-                            BRIGHTNESS_OVERRIDE_FULL.times(100).toInt()
+                            BRIGHTNESS_OVERRIDE_FULL.times(1000).toInt()
                         activity.binding.gestureBrightnessProgressBar.progress =
-                            lp.screenBrightness.times(100).toInt()
-                        val process =
-                            (lp.screenBrightness / BRIGHTNESS_OVERRIDE_FULL).times(100).toInt()
-                        activity.binding.gestureBrightnessText.text = "$process%"
-                        activity.binding.gestureBrightnessImage.setImageLevel(process)
+                            lp.screenBrightness.times(1000).toInt()
+                        val process = (lp.screenBrightness / BRIGHTNESS_OVERRIDE_FULL).times(100)
+                        activity.binding.gestureBrightnessText.text = String.format("%.1f%%", process)
+                        activity.binding.gestureBrightnessImage.setImageLevel(process.toInt())
 
                         swipeGestureBrightnessOpen = true
                     }


### PR DESCRIPTION
This PR makes it easier to adjust brightness at low levels, which is often difficult on high-brightness screens.

**Non-linear Sensitivity**: Adjustments are now much more precise at low brightness (0-15%), smoothly accelerating to normal speed as brightness increases.

**Decimal Display**: The player UI now shows one decimal place (e.g., `1.2%`) for better visual feedback of these fine adjustments. (1000 steps vs 100)

![linear_old](https://github.com/user-attachments/assets/a2c0bf72-8597-4409-8dd6-bb2fc4cb493d)
![precision_new](https://github.com/user-attachments/assets/5e621160-afcd-4c46-90c1-a5ca75d60878)
