### PR TITLE
feat: support jellyfin://item/<id> deep links into the phone app

### DIFF
--- a/app/phone/src/main/AndroidManifest.xml
+++ b/app/phone/src/main/AndroidManifest.xml
@@ -34,11 +34,21 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustPan">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="jellyfin"
+                    android:host="item" />
             </intent-filter>
 
         </activity>

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/MainActivity.kt
@@ -1,27 +1,42 @@
 package dev.jdtech.jellyfin
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.utils.LocalOfflineMode
+import dev.jdtech.jellyfin.repository.JellyfinRepository
 import dev.jdtech.jellyfin.viewmodels.MainViewModel
+import java.util.UUID
+import javax.inject.Inject
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels()
 
+    @Inject lateinit var jellyfinRepository: JellyfinRepository
+
+    private var pendingDeepLinkItemId by mutableStateOf<UUID?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         enableEdgeToEdge()
+
+        pendingDeepLinkItemId = parseDeepLink(intent)
 
         setContent {
             val state by viewModel.state.collectAsStateWithLifecycle()
@@ -36,9 +51,40 @@ class MainActivity : AppCompatActivity() {
                             hasCurrentServer = state.hasCurrentServer,
                             hasCurrentUser = state.hasCurrentUser,
                         )
+
+                        val itemId = pendingDeepLinkItemId
+                        if (itemId != null) {
+                            LaunchedEffect(itemId, state.hasCurrentUser) {
+                                if (state.hasCurrentUser) {
+                                    val item = runCatching { jellyfinRepository.getItem(itemId) }
+                                        .onFailure { Timber.w(it, "Deep link lookup failed for %s", itemId) }
+                                        .getOrNull()
+                                    if (item != null) {
+                                        navigateToItem(navController, item)
+                                    }
+                                }
+                                pendingDeepLinkItemId = null
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        parseDeepLink(intent)?.let { pendingDeepLinkItemId = it }
+    }
+
+    private fun parseDeepLink(intent: Intent?): UUID? {
+        if (intent?.action != Intent.ACTION_VIEW) return null
+        val data: Uri = intent.data ?: return null
+        if (data.scheme != "jellyfin" || data.host != "item") return null
+        val rawId = data.pathSegments.firstOrNull()?.takeIf { it.isNotBlank() } ?: return null
+        return runCatching { UUID.fromString(rawId) }
+            .onFailure { Timber.w("Ignoring deep link with invalid item id: %s", rawId) }
+            .getOrNull()
     }
 }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/NavigationRoot.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/NavigationRoot.kt
@@ -460,7 +460,7 @@ private fun navigateHome(navController: NavHostController) {
     }
 }
 
-private fun navigateToItem(navController: NavHostController, item: FindroidItem) {
+internal fun navigateToItem(navController: NavHostController, item: FindroidItem) {
     when (item) {
         is FindroidBoxSet ->
             navController.safeNavigate(


### PR DESCRIPTION
Hello! 

I'm creating this PR in an effort to support jellyfin deep links on the Findroid phone app.

### Summary

External apps currently cannot deep-link into Findroid. the manifest only declares MAIN/LAUNCHER. This PR adds an ACTION_VIEW filter on MainActivity for `jellyfin://item/<uuid>` so other apps (launchers, automations, the Jellyfin web/desktop ecosystem) can open Findroid directly on a screen. Someone created a PR on the official client to add the same scheme in [jellyfin/jellyfin-android#1933](https://github.com/jellyfin/jellyfin-android/pull/1933). (that has not been merged yet). This PR mirrors that pattern in Findroid.

### Changes

- AndroidManifest.xml: second <intent-filter> on MainActivity. existing MAIN/LAUNCHER untouched. launchMode="singleTask" so re-entry routes through onNewIntent.
- MainActivity.kt: parse intent.data, validate the path as a UUID, resolve via the existing JellyfinRepository.getItem (already DI-provided), and route through the existing navigateToItem helper. onNewIntent covers warm-start. Malformed URIs, unknown ids, and unauthed state all no-op gracefully.
- NavigationRoot.kt: navigateToItem made internal so MainActivity can reuse it (no behavior change for existing call sites). If owners prefer to keep this private, we can wire in a similar logic in MainActivity.

### Notes

- I went with `jellyfin://item/<id>` because Jellyfin item ids are globally unique UUIDs, so the item type can be discovered server-side rather than baked into the URL.
- Right now if no user is signed in, the deep link is dropped rather than stashed across the login flow.