### PR TITLE
feat: Long click to copy text

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/EpisodeScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/EpisodeScreen.kt
@@ -59,6 +59,7 @@ import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.presentation.utils.LocalOfflineMode
 import dev.jdtech.jellyfin.presentation.utils.rememberSafePadding
 import dev.jdtech.jellyfin.utils.ObserveAsEvents
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 import dev.jdtech.jellyfin.utils.format
 import java.util.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -159,18 +160,20 @@ private fun EpisodeScreenLayout(
                                             episode.parentIndexNumber,
                                         )
                                     }
+                            val episodeNumberText = stringResource(
+                                id = CoreR.string.episode_number,
+                                episode.indexNumber,
+                            )
+                            val prefixText = "$seasonName - $episodeNumberText"
                             Text(
-                                text =
-                                    "$seasonName - " +
-                                        stringResource(
-                                            id = CoreR.string.episode_number,
-                                            episode.indexNumber,
-                                        ),
+                                text = prefixText,
+                                modifier = Modifier.copyOnLongClick(prefixText),
                                 maxLines = 1,
                                 style = MaterialTheme.typography.labelLarge,
                             )
                             Text(
                                 text = episode.name,
+                                modifier = Modifier.copyOnLongClick(episode.name),
                                 overflow = TextOverflow.Ellipsis,
                                 maxLines = 3,
                                 style = MaterialTheme.typography.headlineMedium,
@@ -186,21 +189,28 @@ private fun EpisodeScreenLayout(
                         verticalAlignment = Alignment.Bottom,
                     ) {
                         episode.premiereDate?.let { premiereDate ->
+                            val dateText = premiereDate.format()
                             Text(
-                                text = premiereDate.format(),
+                                text = dateText,
+                                modifier = Modifier.copyOnLongClick(dateText),
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                         }
+                        val runtimeText = stringResource(
+                            CoreR.string.runtime_minutes,
+                            episode.runtimeTicks.div(600000000),
+                        )
                         Text(
-                            text =
-                                stringResource(
-                                    CoreR.string.runtime_minutes,
-                                    episode.runtimeTicks.div(600000000),
-                                ),
+                            text = runtimeText,
+                            modifier = Modifier.copyOnLongClick(runtimeText),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                         episode.communityRating?.let { communityRating ->
-                            Row(verticalAlignment = Alignment.Bottom) {
+                            val ratingText = "%.1f".format(communityRating)
+                            Row(
+                                modifier = Modifier.copyOnLongClick(ratingText),
+                                verticalAlignment = Alignment.Bottom
+                            ) {
                                 Icon(
                                     painter = painterResource(CoreR.drawable.ic_star),
                                     contentDescription = null,

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/MovieScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/MovieScreen.kt
@@ -58,6 +58,7 @@ import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.presentation.utils.LocalOfflineMode
 import dev.jdtech.jellyfin.presentation.utils.rememberSafePadding
 import dev.jdtech.jellyfin.utils.ObserveAsEvents
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 import java.util.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
 
@@ -155,6 +156,7 @@ private fun MovieScreenLayout(
                         ) {
                             Text(
                                 text = movie.name,
+                                modifier = Modifier.copyOnLongClick(movie.name),
                                 overflow = TextOverflow.Ellipsis,
                                 maxLines = 3,
                                 style = MaterialTheme.typography.headlineMedium,
@@ -163,6 +165,7 @@ private fun MovieScreenLayout(
                                 if (originalTitle != movie.name) {
                                     Text(
                                         text = originalTitle,
+                                        modifier = Modifier.copyOnLongClick(originalTitle),
                                         overflow = TextOverflow.Ellipsis,
                                         maxLines = 1,
                                         style = MaterialTheme.typography.bodyMedium,
@@ -180,24 +183,35 @@ private fun MovieScreenLayout(
                         verticalAlignment = Alignment.Bottom,
                     ) {
                         movie.premiereDate?.let { premiereDate ->
+                            val premiereDateText = premiereDate.year.toString()
                             Text(
-                                text = premiereDate.year.toString(),
+                                text = premiereDateText,
+                                modifier = Modifier.copyOnLongClick(premiereDateText),
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                         }
+                        val runtimeText = stringResource(
+                            CoreR.string.runtime_minutes,
+                            movie.runtimeTicks.div(600000000),
+                        )
                         Text(
-                            text =
-                                stringResource(
-                                    CoreR.string.runtime_minutes,
-                                    movie.runtimeTicks.div(600000000),
-                                ),
+                            text = runtimeText,
+                            modifier = Modifier.copyOnLongClick(runtimeText),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                         movie.officialRating?.let { officialRating ->
-                            Text(text = officialRating, style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                text = officialRating,
+                                modifier = Modifier.copyOnLongClick(officialRating),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
                         }
                         movie.communityRating?.let { communityRating ->
-                            Row(verticalAlignment = Alignment.Bottom) {
+                            val ratingText = "%.1f".format(communityRating)
+                            Row(
+                                modifier = Modifier.copyOnLongClick(ratingText),
+                                verticalAlignment = Alignment.Bottom
+                            ) {
                                 Icon(
                                     painter = painterResource(CoreR.drawable.ic_star),
                                     contentDescription = null,

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/PersonScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/PersonScreen.kt
@@ -49,6 +49,7 @@ import dev.jdtech.jellyfin.presentation.film.components.OverviewText
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.presentation.utils.rememberSafePadding
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 import java.util.UUID
 
 @Composable
@@ -107,6 +108,7 @@ private fun PersonScreenLayout(state: PersonState, onAction: (PersonAction) -> U
                             ) {
                                 Text(
                                     text = person.name,
+                                    modifier = Modifier.copyOnLongClick(person.name),
                                     style = MaterialTheme.typography.headlineMedium,
                                 )
                                 if (person.overview.isNotBlank()) {
@@ -125,6 +127,7 @@ private fun PersonScreenLayout(state: PersonState, onAction: (PersonAction) -> U
                             PersonImage(person)
                             Text(
                                 text = person.name,
+                                modifier = Modifier.copyOnLongClick(person.name),
                                 style = MaterialTheme.typography.headlineMedium,
                             )
                             if (person.overview.isNotBlank()) {

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/SeasonScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/SeasonScreen.kt
@@ -49,6 +49,7 @@ import dev.jdtech.jellyfin.presentation.film.components.ItemTopBar
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.presentation.utils.rememberSafePadding
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 import java.util.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
 
@@ -126,12 +127,14 @@ private fun SeasonScreenLayout(state: SeasonState, onAction: (SeasonAction) -> U
                                 Column(modifier = Modifier) {
                                     Text(
                                         text = season.seriesName,
+                                        modifier = Modifier.copyOnLongClick(season.seriesName),
                                         overflow = TextOverflow.Ellipsis,
                                         maxLines = 1,
                                         style = MaterialTheme.typography.bodyLarge,
                                     )
                                     Text(
                                         text = season.name,
+                                        modifier = Modifier.copyOnLongClick(season.name),
                                         overflow = TextOverflow.Ellipsis,
                                         maxLines = 3,
                                         style = MaterialTheme.typography.headlineMedium,

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/ShowScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/ShowScreen.kt
@@ -59,6 +59,7 @@ import dev.jdtech.jellyfin.presentation.film.components.OverviewText
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.presentation.utils.rememberSafePadding
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 import dev.jdtech.jellyfin.utils.getShowDateString
 import java.util.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -131,6 +132,7 @@ private fun ShowScreenLayout(state: ShowState, onAction: (ShowAction) -> Unit) {
                         ) {
                             Text(
                                 text = show.name,
+                                modifier = Modifier.copyOnLongClick(show.name),
                                 overflow = TextOverflow.Ellipsis,
                                 maxLines = 3,
                                 style = MaterialTheme.typography.headlineMedium,
@@ -139,6 +141,7 @@ private fun ShowScreenLayout(state: ShowState, onAction: (ShowAction) -> Unit) {
                                 if (originalTitle != show.name) {
                                     Text(
                                         text = originalTitle,
+                                        modifier = Modifier.copyOnLongClick(originalTitle),
                                         overflow = TextOverflow.Ellipsis,
                                         maxLines = 1,
                                         style = MaterialTheme.typography.bodyMedium,
@@ -155,23 +158,34 @@ private fun ShowScreenLayout(state: ShowState, onAction: (ShowAction) -> Unit) {
                         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.small),
                         verticalAlignment = Alignment.Bottom,
                     ) {
+                        val dateText = getShowDateString(show)
                         Text(
-                            text = getShowDateString(show),
+                            text = dateText,
+                            modifier = Modifier.copyOnLongClick(dateText),
                             style = MaterialTheme.typography.bodyMedium,
                         )
+                        val runtimeText = stringResource(
+                            CoreR.string.runtime_minutes,
+                            show.runtimeTicks.div(600000000),
+                        )
                         Text(
-                            text =
-                                stringResource(
-                                    CoreR.string.runtime_minutes,
-                                    show.runtimeTicks.div(600000000),
-                                ),
+                            text = runtimeText,
+                            modifier = Modifier.copyOnLongClick(runtimeText),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                         show.officialRating?.let { officialRating ->
-                            Text(text = officialRating, style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                text = officialRating,
+                                modifier = Modifier.copyOnLongClick(officialRating),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
                         }
                         show.communityRating?.let { communityRating ->
-                            Row(verticalAlignment = Alignment.Bottom) {
+                            val ratingText = "%.1f".format(communityRating)
+                            Row(
+                                modifier = Modifier.copyOnLongClick(ratingText),
+                                verticalAlignment = Alignment.Bottom
+                            ) {
                                 Icon(
                                     painter = painterResource(CoreR.drawable.ic_star),
                                     contentDescription = null,

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/HomeCarouselItem.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/HomeCarouselItem.kt
@@ -1,7 +1,6 @@
 package dev.jdtech.jellyfin.presentation.film.components
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,6 +29,7 @@ import dev.jdtech.jellyfin.models.FindroidMovie
 import dev.jdtech.jellyfin.models.FindroidShow
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 
 @Composable
 fun HomeCarouselItem(item: FindroidItem, onAction: (HomeAction) -> Unit) {
@@ -42,9 +42,13 @@ fun HomeCarouselItem(item: FindroidItem, onAction: (HomeAction) -> Unit) {
 
     Box(
         modifier =
-            Modifier.aspectRatio(1.77f).clip(MaterialTheme.shapes.large).clickable {
-                onAction(HomeAction.OnItemClick(item))
-            }
+            Modifier
+                .aspectRatio(1.77f)
+                .clip(MaterialTheme.shapes.large)
+                .copyOnLongClick(
+                    text = item.name,
+                    onClick = { onAction(HomeAction.OnItemClick(item)) }
+                )
     ) {
         AsyncImage(
             model = item.images.backdrop,

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/InfoText.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/InfoText.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import dev.jdtech.jellyfin.core.R as CoreR
 import dev.jdtech.jellyfin.models.FindroidItemPerson
 import dev.jdtech.jellyfin.presentation.theme.spacings
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 
 @Composable
 fun InfoText(
@@ -18,21 +20,25 @@ fun InfoText(
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.small)) {
         if (genres.isNotEmpty()) {
+            val genresText = genres.joinToString()
             Text(
-                text = "${stringResource(CoreR.string.genres)}: ${genres.joinToString()}",
+                text = "${stringResource(CoreR.string.genres)}: $genresText",
+                modifier = Modifier.copyOnLongClick(genresText),
                 style = MaterialTheme.typography.bodyMedium,
             )
         }
         if (director != null) {
             Text(
                 text = "${stringResource(CoreR.string.director)}: ${director.name}",
+                modifier = Modifier.copyOnLongClick(director.name),
                 style = MaterialTheme.typography.bodyMedium,
             )
         }
         if (writers.isNotEmpty()) {
+            val writersText = writers.joinToString { it.name }
             Text(
-                text =
-                    "${stringResource(CoreR.string.writers)}: ${writers.joinToString { it.name }}",
+                text = "${stringResource(CoreR.string.writers)}: $writersText",
+                modifier = Modifier.copyOnLongClick(writersText),
                 style = MaterialTheme.typography.bodyMedium,
             )
         }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/ItemCard.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/ItemCard.kt
@@ -1,6 +1,5 @@
 package dev.jdtech.jellyfin.presentation.film.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +27,7 @@ import dev.jdtech.jellyfin.models.FindroidItem
 import dev.jdtech.jellyfin.models.isDownloaded
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 
 @Composable
 fun ItemCard(
@@ -46,7 +46,7 @@ fun ItemCard(
             modifier
                 .width(width.dp)
                 .clip(MaterialTheme.shapes.small)
-                .clickable(onClick = { onClick(item) })
+                .copyOnLongClick(item.name, onClick = { onClick(item) })
     ) {
         Surface(shape = MaterialTheme.shapes.small) {
             Box {
@@ -72,21 +72,24 @@ fun ItemCard(
             }
         }
         Spacer(modifier = Modifier.height(MaterialTheme.spacings.extraSmall))
+        val titleText = if (item is FindroidEpisode) item.seriesName else item.name
         Text(
-            text = if (item is FindroidEpisode) item.seriesName else item.name,
+            text = titleText,
+            modifier = Modifier.copyOnLongClick(titleText),
             style = MaterialTheme.typography.bodyMedium,
             maxLines = if (item is FindroidEpisode) 1 else 2,
             overflow = TextOverflow.Ellipsis,
         )
         if (item is FindroidEpisode) {
+            val episodeText = stringResource(
+                id = R.string.episode_name_extended,
+                item.parentIndexNumber,
+                item.indexNumber,
+                item.name,
+            )
             Text(
-                text =
-                    stringResource(
-                        id = R.string.episode_name_extended,
-                        item.parentIndexNumber,
-                        item.indexNumber,
-                        item.name,
-                    ),
+                text = episodeText,
+                modifier = Modifier.copyOnLongClick(episodeText),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
                 maxLines = 1,

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/OverviewText.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/OverviewText.kt
@@ -1,7 +1,6 @@
 package dev.jdtech.jellyfin.presentation.film.components
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -16,6 +15,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import dev.jdtech.jellyfin.core.presentation.dummy.dummyMovie
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 
 @Composable
 fun OverviewText(text: String, maxCollapsedLines: Int = Int.MAX_VALUE) {
@@ -25,13 +25,14 @@ fun OverviewText(text: String, maxCollapsedLines: Int = Int.MAX_VALUE) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = text,
-            modifier =
-                Modifier.then(
-                        if (showChevron)
-                            Modifier.clickable { isOverviewExpanded = !isOverviewExpanded }
-                        else Modifier
-                    )
-                    .animateContentSize(),
+            modifier = Modifier
+                .copyOnLongClick(
+                    text = text,
+                    onClick = if (showChevron) {
+                        { isOverviewExpanded = !isOverviewExpanded }
+                    } else null
+                )
+                .animateContentSize(),
             overflow = TextOverflow.Ellipsis,
             maxLines = if (isOverviewExpanded) Int.MAX_VALUE else maxCollapsedLines,
             onTextLayout = { textLayoutResult ->

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/PersonItem.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/PersonItem.kt
@@ -1,7 +1,6 @@
 package dev.jdtech.jellyfin.presentation.film.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,12 +20,13 @@ import dev.jdtech.jellyfin.core.presentation.dummy.dummyPerson
 import dev.jdtech.jellyfin.models.FindroidItemPerson
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
+import dev.jdtech.jellyfin.utils.copyOnLongClick
 
 @Composable
 fun PersonItem(person: FindroidItemPerson, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Column(
         modifier =
-            modifier.width(110.dp).clip(MaterialTheme.shapes.small).clickable(onClick = onClick)
+            modifier.width(110.dp).clip(MaterialTheme.shapes.small).copyOnLongClick(person.name,onClick = onClick)
     ) {
         AsyncImage(
             model = person.image.uri,
@@ -41,12 +41,14 @@ fun PersonItem(person: FindroidItemPerson, onClick: () -> Unit, modifier: Modifi
         Spacer(Modifier.height(MaterialTheme.spacings.extraSmall))
         Text(
             text = person.name,
+            modifier = Modifier.copyOnLongClick(person.name),
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,
             style = MaterialTheme.typography.bodyMedium,
         )
         Text(
             text = person.role,
+            modifier = Modifier.copyOnLongClick(person.role),
             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(projects.player.core)
     implementation(projects.settings)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.core)
     implementation(libs.androidx.hilt.work)

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/ClipboardUtils.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/ClipboardUtils.kt
@@ -1,0 +1,33 @@
+package dev.jdtech.jellyfin.utils
+
+import android.content.ClipData
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.launch
+
+@Composable
+fun Modifier.copyOnLongClick(text: String, onClick: (() -> Unit)? = null): Modifier {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+
+    return this.combinedClickable(
+        onClick = onClick ?: {},
+        onLongClickLabel = "Copy text",
+        onLongClick = {
+            scope.launch {
+                clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("Copied text", text)))
+            }
+            // Only show a toast for Android 12 and lower.
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2)
+                Toast.makeText(context, text, Toast.LENGTH_SHORT).show()
+        }
+    )
+}


### PR DESCRIPTION
This allows the user to long click on a text to copy to system clipboard

What is implemented:
movies and shows: name, year, runtime, rating, overview, genres, director, writers, episode name
cast: name, overview

Fixes #1064 

[recording of hold to copy.webm](https://github.com/user-attachments/assets/d31d0842-8d84-4ad3-8d2d-850ca55aa5ad)


pre android 13 toast example as newer android versions already implement this


<img width="300" height="650" alt="pre android 13 toast example" src="https://github.com/user-attachments/assets/e9549c97-d190-44b1-b8d7-f7604d6ebacc" /> 

If you have other text fields that you want to be able to copy, just let me know and i'll implement it in a jiffy :)