### PR TITLE
Feat: Watched items toggle button in libary

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
@@ -126,6 +126,12 @@ private fun LibraryScreenLayout(
                     }
                 },
                 actions = {
+                    IconButton(onClick = { onAction(LibraryAction.ToggleWatchedFilter(!state.filterWatched)) }) {
+                        Icon(
+                            painter = painterResource(if (state.filterWatched) CoreR.drawable.ic_eye_off else CoreR.drawable.ic_eye),
+                            contentDescription = null,
+                        )
+                    }
                     IconButton(onClick = { showSortByDialog = true }) {
                         Icon(
                             painter = painterResource(CoreR.drawable.ic_arrow_down_up),

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
@@ -86,6 +86,7 @@ fun LibraryScreen(
                             navigateToLibrary(action.item.id, action.item.name, libraryType)
                     }
                 }
+
                 else -> Unit
             }
             viewModel.onAction(action)
@@ -114,14 +115,23 @@ private fun LibraryScreenLayout(
                 horizontal = MaterialTheme.spacings.default * 2,
                 vertical = MaterialTheme.spacings.large,
             ),
-        modifier = Modifier.fillMaxSize().focusRequester(focusRequester),
+        modifier = Modifier .fillMaxSize() .focusRequester(focusRequester),
     ) {
         item(span = { GridItemSpan(this.maxLineSpan) }) {
             Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.default),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(text = libraryName, style = MaterialTheme.typography.displayMedium)
+                Text( text = libraryName, style = MaterialTheme.typography.displayMedium, modifier = Modifier.weight(1f))
+                Button(onClick = { onAction(LibraryAction.ToggleWatchedFilter(!state.filterWatched)) }) {
+                    Icon(
+                        painter = painterResource(if (state.filterWatched) CoreR.drawable.ic_eye_off else CoreR.drawable.ic_eye),
+                        contentDescription = stringResource(CoreR.string.toggle_watched),
+                        modifier = Modifier.size(ButtonDefaults.IconSize),
+                    )
+                    Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                    Text(text = stringResource(CoreR.string.toggle_watched))
+                }
                 Button(onClick = { showSortByDialog = true }) {
                     Icon(
                         painter = painterResource(CoreR.drawable.ic_arrow_down_up),

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="shows_label">TV Shows</string>
     <string name="episodes_label">Episodes</string>
     <string name="hide">Hide</string>
+    <string name="toggle_watched">Watched</string>
     <string name="sort_by">Sort by</string>
     <string name="sort_order">Sort order</string>
     <string name="close">Close</string>

--- a/data/src/main/java/dev/jdtech/jellyfin/repository/ItemsPagingSource.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/ItemsPagingSource.kt
@@ -7,6 +7,7 @@ import dev.jdtech.jellyfin.models.SortBy
 import dev.jdtech.jellyfin.models.SortOrder
 import java.util.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemFilter
 import timber.log.Timber
 
 class ItemsPagingSource(
@@ -16,6 +17,7 @@ class ItemsPagingSource(
     private val recursive: Boolean,
     private val sortBy: SortBy,
     private val sortOrder: SortOrder,
+    private val filters: List<ItemFilter>?,
 ) : PagingSource<Int, FindroidItem>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FindroidItem> {
         val position = params.key ?: 0
@@ -30,6 +32,7 @@ class ItemsPagingSource(
                     recursive = recursive,
                     sortBy = sortBy,
                     sortOrder = sortOrder,
+                    filters = filters,
                     startIndex = position,
                     limit = params.loadSize,
                 )

--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepository.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepository.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ItemFields
+import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.PublicSystemInfo
 import org.jellyfin.sdk.model.api.UserConfiguration
 
@@ -43,6 +44,7 @@ interface JellyfinRepository {
         recursive: Boolean = false,
         sortBy: SortBy = SortBy.defaultValue,
         sortOrder: SortOrder = SortOrder.ASCENDING,
+        filters: List<ItemFilter>? = null,
         startIndex: Int? = null,
         limit: Int? = null,
     ): List<FindroidItem>
@@ -53,6 +55,7 @@ interface JellyfinRepository {
         recursive: Boolean = false,
         sortBy: SortBy = SortBy.defaultValue,
         sortOrder: SortOrder = SortOrder.ASCENDING,
+        filters: List<ItemFilter>? = null,
     ): Flow<PagingData<FindroidItem>>
 
     suspend fun getPerson(personId: UUID): FindroidPerson

--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
@@ -122,6 +122,7 @@ class JellyfinRepositoryImpl(
         recursive: Boolean,
         sortBy: SortBy,
         sortOrder: SortOrder,
+        filters: List<ItemFilter>?,
         startIndex: Int?,
         limit: Int?,
     ): List<FindroidItem> =
@@ -134,6 +135,7 @@ class JellyfinRepositoryImpl(
                     recursive = recursive,
                     sortBy = listOf(ItemSortBy.fromName(sortBy.sortString)),
                     sortOrder = listOf(ItemSortOrder.fromName(sortOrder.sortString)),
+                    filters = filters,
                     startIndex = startIndex,
                     limit = limit,
                 )
@@ -148,11 +150,12 @@ class JellyfinRepositoryImpl(
         recursive: Boolean,
         sortBy: SortBy,
         sortOrder: SortOrder,
+        filters: List<ItemFilter>?,
     ): Flow<PagingData<FindroidItem>> {
         return Pager(
                 config = PagingConfig(pageSize = 10, enablePlaceholders = false),
                 pagingSourceFactory = {
-                    ItemsPagingSource(this, parentId, includeTypes, recursive, sortBy, sortOrder)
+                    ItemsPagingSource(this, parentId, includeTypes, recursive, sortBy, sortOrder,filters)
                 },
             )
             .flow

--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryOfflineImpl.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryOfflineImpl.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ItemFields
+import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.PublicSystemInfo
 import org.jellyfin.sdk.model.api.UserConfiguration
 
@@ -82,6 +83,7 @@ class JellyfinRepositoryOfflineImpl(
         recursive: Boolean,
         sortBy: SortBy,
         sortOrder: SortOrder,
+        filters: List<ItemFilter>?,
         startIndex: Int?,
         limit: Int?,
     ): List<FindroidItem> {
@@ -94,6 +96,7 @@ class JellyfinRepositoryOfflineImpl(
         recursive: Boolean,
         sortBy: SortBy,
         sortOrder: SortOrder,
+        filters: List<ItemFilter>?,
     ): Flow<PagingData<FindroidItem>> {
         TODO("Not yet implemented")
     }

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryAction.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryAction.kt
@@ -10,4 +10,6 @@ sealed interface LibraryAction {
     data object OnBackClick : LibraryAction
 
     data class ChangeSorting(val sortBy: SortBy, val sortOrder: SortOrder) : LibraryAction
+
+    data class ToggleWatchedFilter(val enabled: Boolean) : LibraryAction
 }

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryState.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryState.kt
@@ -11,6 +11,7 @@ data class LibraryState(
     val items: Flow<PagingData<FindroidItem>> = emptyFlow(),
     val sortBy: SortBy = SortBy.NAME,
     val sortOrder: SortOrder = SortOrder.ASCENDING,
+    val filterWatched: Boolean = false,
     val isLoading: Boolean = false,
     val error: Exception? = null,
 )

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryViewModel.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemFilter
 
 @HiltViewModel
 class LibraryViewModel
@@ -31,6 +32,7 @@ constructor(
 
     lateinit var sortBy: SortBy
     lateinit var sortOrder: SortOrder
+    private var filterWatched: Boolean = false
 
     fun setup(parentId: UUID, libraryType: CollectionType) {
         this.parentId = parentId
@@ -72,6 +74,8 @@ constructor(
                                 else sortBy, // Jellyfin uses a different enum for sorting series by
                             // data played
                             sortOrder = sortOrder,
+                            filters =
+                                if (filterWatched) listOf(ItemFilter.IS_UNPLAYED) else null,
                         )
                         .cachedIn(viewModelScope)
                 _state.emit(_state.value.copy(items = items))
@@ -85,7 +89,8 @@ constructor(
         if (!::sortBy.isInitialized || !::sortOrder.isInitialized) {
             sortBy = SortBy.fromString(appPreferences.getValue(appPreferences.sortBy))
             sortOrder = SortOrder.fromString(appPreferences.getValue(appPreferences.sortOrder))
-            _state.emit(_state.value.copy(sortBy = sortBy, sortOrder = sortOrder))
+            filterWatched = appPreferences.getValue(appPreferences.filterWatched)
+            _state.emit(_state.value.copy(sortBy = sortBy, sortOrder = sortOrder, filterWatched = filterWatched))
         }
     }
 
@@ -99,6 +104,15 @@ constructor(
         }
     }
 
+    private fun toggleWatchedFilter(enabled: Boolean) {
+        this.filterWatched = enabled
+        viewModelScope.launch {
+            _state.emit(_state.value.copy(filterWatched = enabled))
+            appPreferences.setValue(appPreferences.filterWatched, enabled)
+            loadItems()
+        }
+    }
+
     fun onAction(action: LibraryAction) {
         when (action) {
             is LibraryAction.ChangeSorting -> {
@@ -107,6 +121,7 @@ constructor(
                     loadItems()
                 }
             }
+            is LibraryAction.ToggleWatchedFilter -> toggleWatchedFilter(action.enabled)
             else -> Unit
         }
     }

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
@@ -90,6 +90,9 @@ class AppPreferences @Inject constructor(val sharedPreferences: SharedPreference
     val socketTimeout =
         Preference("pref_network_socket_timeout", Constants.NETWORK_DEFAULT_SOCKET_TIMEOUT)
 
+    // Library filter
+    val filterWatched = Preference("pref_filter_watched", false)
+
     // Cache
     val imageCache = Preference("pref_image_cache", true)
     val imageCacheSize = Preference("pref_image_cache_size", 20)


### PR DESCRIPTION
Adds a button to the library view to filter out watched items.
The state is stored and is shared between all the libraries like how SortBy is

The Phone UI in action:

[phone ui example](https://github.com/user-attachments/assets/c0eda6a8-0d65-42dd-a83d-e030882ea009)


The TV UI:

[recording of TV ui](https://github.com/user-attachments/assets/abdefe0a-a264-4a17-aeca-2b514a99bbfd)


closes: #860
closes: #1175