### PR TITLE
feat: add episode sorting to TV show libraries

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
@@ -82,6 +82,7 @@ fun LibraryScreen(
 
     LibraryScreenLayout(
         libraryName = libraryName,
+        libraryType = libraryType,
         state = state,
         onAction = { action ->
             when (action) {
@@ -98,6 +99,7 @@ fun LibraryScreen(
 @Composable
 private fun LibraryScreenLayout(
     libraryName: String,
+    libraryType: CollectionType,
     state: LibraryState,
     onAction: (LibraryAction) -> Unit,
 ) {
@@ -156,9 +158,14 @@ private fun LibraryScreenLayout(
                     item?.let { item ->
                         ItemCard(
                             item = item,
-                            direction = Direction.VERTICAL,
+                            direction =
+                                if (state.sortBy.displaysEpisodes) {
+                                    Direction.HORIZONTAL
+                                } else {
+                                    Direction.VERTICAL
+                                },
                             onClick = { onAction(LibraryAction.OnItemClick(item)) },
-                            modifier = Modifier.animateItem(),
+                            modifier = Modifier.fillMaxWidth().animateItem(),
                         )
                     }
                 }
@@ -170,6 +177,7 @@ private fun LibraryScreenLayout(
         SortByDialog(
             currentSortBy = state.sortBy,
             currentSortOrder = state.sortOrder,
+            includeEpisodeSortOptions = libraryType == CollectionType.TvShows,
             onUpdate = { sortBy, sortOrder ->
                 onAction(LibraryAction.ChangeSorting(sortBy, sortOrder))
             },
@@ -219,6 +227,7 @@ private fun LibraryScreenLayoutPreview() {
     FindroidTheme {
         LibraryScreenLayout(
             libraryName = "Movies",
+            libraryType = CollectionType.Movies,
             state = LibraryState(items = items),
             onAction = {},
         )

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/SortByDialog.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/SortByDialog.kt
@@ -41,21 +41,24 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import dev.jdtech.jellyfin.core.R as CoreR
-import dev.jdtech.jellyfin.models.SortBy
+import dev.jdtech.jellyfin.film.presentation.library.LibrarySortBy
 import dev.jdtech.jellyfin.models.SortOrder
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 
 @Composable
 fun SortByDialog(
-    currentSortBy: SortBy,
+    currentSortBy: LibrarySortBy,
     currentSortOrder: SortOrder,
-    onUpdate: (sortBy: SortBy, sortOrder: SortOrder) -> Unit,
+    includeEpisodeSortOptions: Boolean = false,
+    onUpdate: (sortBy: LibrarySortBy, sortOrder: SortOrder) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-    val optionValues = SortBy.entries
     val optionNames = stringArrayResource(CoreR.array.sort_by_options)
-    val options = optionValues.zip(optionNames)
+    val options =
+        LibrarySortBy.entries.zip(optionNames).filter {
+            includeEpisodeSortOptions || !it.first.displaysEpisodes
+        }
 
     val orderValues = SortOrder.entries
     val orderNames = stringArrayResource(CoreR.array.sort_order_options)
@@ -152,9 +155,9 @@ fun SortByDialog(
 
 @Composable
 private fun SortByDialogItem(
-    option: Pair<SortBy, String>,
+    option: Pair<LibrarySortBy, String>,
     isSelected: Boolean,
-    onSelect: (SortBy) -> Unit,
+    onSelect: (LibrarySortBy) -> Unit,
 ) {
     Row(
         modifier =
@@ -174,7 +177,7 @@ private fun SortByDialogItem(
 private fun SortByDialogPreview() {
     FindroidTheme {
         SortByDialog(
-            currentSortBy = SortBy.NAME,
+            currentSortBy = LibrarySortBy.NAME,
             currentSortOrder = SortOrder.ASCENDING,
             onUpdate = { _, _ -> },
             onDismissRequest = {},
@@ -186,6 +189,10 @@ private fun SortByDialogPreview() {
 @Composable
 private fun SortByDialogItemPreview() {
     FindroidTheme {
-        SortByDialogItem(option = Pair(SortBy.NAME, "Title"), isSelected = true, onSelect = {})
+        SortByDialogItem(
+            option = Pair(LibrarySortBy.NAME, "Title"),
+            isSelected = true,
+            onSelect = {},
+        )
     }
 }

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/NavigationRoot.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/NavigationRoot.kt
@@ -183,6 +183,14 @@ fun NavigationRoot(
                     navController.navigate(MovieRoute(itemId.toString()))
                 },
                 navigateToShow = { itemId -> navController.navigate(ShowRoute(itemId.toString())) },
+                navigateToEpisode = { itemId ->
+                    navController.navigate(
+                        PlayerRoute(
+                            itemId = itemId.toString(),
+                            itemKind = BaseItemKind.EPISODE.serialName,
+                        )
+                    )
+                },
             )
         }
         composable<MovieRoute> { backStackEntry ->

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/film/LibraryScreen.kt
@@ -38,6 +38,7 @@ import dev.jdtech.jellyfin.film.presentation.library.LibraryAction
 import dev.jdtech.jellyfin.film.presentation.library.LibraryState
 import dev.jdtech.jellyfin.film.presentation.library.LibraryViewModel
 import dev.jdtech.jellyfin.models.CollectionType
+import dev.jdtech.jellyfin.models.FindroidEpisode
 import dev.jdtech.jellyfin.models.FindroidFolder
 import dev.jdtech.jellyfin.models.FindroidItem
 import dev.jdtech.jellyfin.models.FindroidMovie
@@ -59,6 +60,7 @@ fun LibraryScreen(
     navigateToLibrary: (libraryId: UUID, libraryName: String, libraryType: CollectionType) -> Unit,
     navigateToMovie: (itemId: UUID) -> Unit,
     navigateToShow: (itemId: UUID) -> Unit,
+    navigateToEpisode: (itemId: UUID) -> Unit,
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -75,6 +77,7 @@ fun LibraryScreen(
 
     LibraryScreenLayout(
         libraryName = libraryName,
+        libraryType = libraryType,
         state = state,
         onAction = { action ->
             when (action) {
@@ -82,6 +85,7 @@ fun LibraryScreen(
                     when (action.item) {
                         is FindroidMovie -> navigateToMovie(action.item.id)
                         is FindroidShow -> navigateToShow(action.item.id)
+                        is FindroidEpisode -> navigateToEpisode(action.item.id)
                         is FindroidFolder ->
                             navigateToLibrary(action.item.id, action.item.name, libraryType)
                     }
@@ -96,6 +100,7 @@ fun LibraryScreen(
 @Composable
 private fun LibraryScreenLayout(
     libraryName: String,
+    libraryType: CollectionType,
     state: LibraryState,
     onAction: (LibraryAction) -> Unit,
 ) {
@@ -138,7 +143,12 @@ private fun LibraryScreenLayout(
             item?.let {
                 ItemCard(
                     item = item,
-                    direction = Direction.VERTICAL,
+                    direction =
+                        if (state.sortBy.displaysEpisodes) {
+                            Direction.HORIZONTAL
+                        } else {
+                            Direction.VERTICAL
+                        },
                     onClick = { onAction(LibraryAction.OnItemClick(item)) },
                     modifier = Modifier.animateItem(),
                 )
@@ -150,6 +160,7 @@ private fun LibraryScreenLayout(
         SortByDialog(
             currentSortBy = state.sortBy,
             currentSortOrder = state.sortOrder,
+            includeEpisodeSortOptions = libraryType == CollectionType.TvShows,
             onUpdate = { sortBy, sortOrder ->
                 onAction(LibraryAction.ChangeSorting(sortBy, sortOrder))
             },
@@ -171,6 +182,7 @@ private fun LibraryScreenLayoutPreview() {
     FindroidTheme {
         LibraryScreenLayout(
             libraryName = "Movies",
+            libraryType = CollectionType.Movies,
             state = LibraryState(items = items),
             onAction = {},
         )

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/film/components/SortByDialog.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/film/components/SortByDialog.kt
@@ -40,21 +40,24 @@ import androidx.tv.material3.RadioButton
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import dev.jdtech.jellyfin.core.R as CoreR
-import dev.jdtech.jellyfin.models.SortBy
+import dev.jdtech.jellyfin.film.presentation.library.LibrarySortBy
 import dev.jdtech.jellyfin.models.SortOrder
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 
 @Composable
 fun SortByDialog(
-    currentSortBy: SortBy,
+    currentSortBy: LibrarySortBy,
     currentSortOrder: SortOrder,
-    onUpdate: (sortBy: SortBy, sortOrder: SortOrder) -> Unit,
+    includeEpisodeSortOptions: Boolean = false,
+    onUpdate: (sortBy: LibrarySortBy, sortOrder: SortOrder) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-    val optionValues = SortBy.entries
     val optionNames = stringArrayResource(CoreR.array.sort_by_options)
-    val options = optionValues.zip(optionNames)
+    val options =
+        LibrarySortBy.entries.zip(optionNames).filter {
+            includeEpisodeSortOptions || !it.first.displaysEpisodes
+        }
 
     val orderValues = SortOrder.entries
     val orderNames = stringArrayResource(CoreR.array.sort_order_options)
@@ -143,9 +146,9 @@ fun SortByDialog(
 
 @Composable
 private fun SortByDialogItem(
-    option: Pair<SortBy, String>,
+    option: Pair<LibrarySortBy, String>,
     isSelected: Boolean,
-    onSelect: (SortBy) -> Unit,
+    onSelect: (LibrarySortBy) -> Unit,
 ) {
     Row(
         modifier =
@@ -169,7 +172,7 @@ private fun SortByDialogItem(
 private fun SortByDialogPreview() {
     FindroidTheme {
         SortByDialog(
-            currentSortBy = SortBy.NAME,
+            currentSortBy = LibrarySortBy.NAME,
             currentSortOrder = SortOrder.ASCENDING,
             onUpdate = { _, _ -> },
             onDismissRequest = {},
@@ -181,6 +184,10 @@ private fun SortByDialogPreview() {
 @Composable
 private fun SortByDialogItemPreview() {
     FindroidTheme {
-        SortByDialogItem(option = Pair(SortBy.NAME, "Title"), isSelected = true, onSelect = {})
+        SortByDialogItem(
+            option = Pair(LibrarySortBy.NAME, "Title"),
+            isSelected = true,
+            onSelect = {},
+        )
     }
 }

--- a/core/src/main/res/values/string_arrays.xml
+++ b/core/src/main/res/values/string_arrays.xml
@@ -7,6 +7,8 @@
         <item>@string/sort_by_options_3</item>
         <item>@string/sort_by_options_4</item>
         <item>@string/sort_by_options_5</item>
+        <item>@string/sort_by_episodes_date_added</item>
+        <item>@string/sort_by_episodes_air_date</item>
     </string-array>
     <string-array name="sort_order_options">
         <item>@string/ascending</item>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -64,6 +64,8 @@
     <string name="sort_by_options_4">Date Played</string>
     <string name="sort_by_options_5">Release Date</string>
     <string name="sort_by_options_6">Random</string>
+    <string name="sort_by_episodes_date_added">Episodes by date added</string>
+    <string name="sort_by_episodes_air_date">Episodes by air date</string>
     <string name="ascending">Ascending</string>
     <string name="descending">Descending</string>
     <string name="runtime_minutes">%1$d mins</string>

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryAction.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryAction.kt
@@ -1,7 +1,6 @@
 package dev.jdtech.jellyfin.film.presentation.library
 
 import dev.jdtech.jellyfin.models.FindroidItem
-import dev.jdtech.jellyfin.models.SortBy
 import dev.jdtech.jellyfin.models.SortOrder
 
 sealed interface LibraryAction {
@@ -9,5 +8,5 @@ sealed interface LibraryAction {
 
     data object OnBackClick : LibraryAction
 
-    data class ChangeSorting(val sortBy: SortBy, val sortOrder: SortOrder) : LibraryAction
+    data class ChangeSorting(val sortBy: LibrarySortBy, val sortOrder: SortOrder) : LibraryAction
 }

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibrarySortBy.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibrarySortBy.kt
@@ -1,0 +1,38 @@
+package dev.jdtech.jellyfin.film.presentation.library
+
+import dev.jdtech.jellyfin.models.SortBy
+
+enum class LibrarySortBy(val repositorySortBy: SortBy, val displaysEpisodes: Boolean = false) {
+    NAME(SortBy.NAME),
+    IMDB_RATING(SortBy.IMDB_RATING),
+    PARENTAL_RATING(SortBy.PARENTAL_RATING),
+    DATE_ADDED(SortBy.DATE_ADDED),
+    DATE_PLAYED(SortBy.DATE_PLAYED),
+    RELEASE_DATE(SortBy.RELEASE_DATE),
+    EPISODES_BY_DATE_ADDED(SortBy.DATE_ADDED, displaysEpisodes = true),
+    EPISODES_BY_AIR_DATE(SortBy.RELEASE_DATE, displaysEpisodes = true);
+
+    companion object {
+        val defaultValue = NAME
+
+        fun fromString(string: String): LibrarySortBy {
+            return try {
+                valueOf(string)
+            } catch (_: IllegalArgumentException) {
+                fromLegacySortBy(string)
+            }
+        }
+
+        private fun fromLegacySortBy(string: String): LibrarySortBy {
+            return when (SortBy.fromString(string)) {
+                SortBy.NAME -> NAME
+                SortBy.IMDB_RATING -> IMDB_RATING
+                SortBy.PARENTAL_RATING -> PARENTAL_RATING
+                SortBy.DATE_ADDED -> DATE_ADDED
+                SortBy.DATE_PLAYED,
+                SortBy.SERIES_DATE_PLAYED -> DATE_PLAYED
+                SortBy.RELEASE_DATE -> RELEASE_DATE
+            }
+        }
+    }
+}

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryState.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryState.kt
@@ -2,14 +2,13 @@ package dev.jdtech.jellyfin.film.presentation.library
 
 import androidx.paging.PagingData
 import dev.jdtech.jellyfin.models.FindroidItem
-import dev.jdtech.jellyfin.models.SortBy
 import dev.jdtech.jellyfin.models.SortOrder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
 data class LibraryState(
     val items: Flow<PagingData<FindroidItem>> = emptyFlow(),
-    val sortBy: SortBy = SortBy.NAME,
+    val sortBy: LibrarySortBy = LibrarySortBy.NAME,
     val sortOrder: SortOrder = SortOrder.ASCENDING,
     val isLoading: Boolean = false,
     val error: Exception? = null,

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryViewModel.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryViewModel.kt
@@ -9,7 +9,6 @@ import dev.jdtech.jellyfin.models.SortBy
 import dev.jdtech.jellyfin.models.SortOrder
 import dev.jdtech.jellyfin.repository.JellyfinRepository
 import dev.jdtech.jellyfin.settings.domain.AppPreferences
-import dev.jdtech.jellyfin.settings.domain.models.Preference
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -92,8 +91,8 @@ constructor(
     private suspend fun initSorting() {
         if (::sortBy.isInitialized && ::sortOrder.isInitialized) return
 
-        val sortByPreference = getSortByPreference()
-        val sortOrderPreference = getSortOrderPreference()
+        val sortByPreference = appPreferences.librarySortBy(parentId)
+        val sortOrderPreference = appPreferences.librarySortOrder(parentId)
         val savedSortBy = appPreferences.getValue(sortByPreference)
         val savedSortOrder = appPreferences.getValue(sortOrderPreference)
 
@@ -124,24 +123,10 @@ constructor(
         this.sortOrder = sortOrder
         viewModelScope.launch {
             _state.emit(_state.value.copy(sortBy = sortBy, sortOrder = sortOrder))
-            appPreferences.setValue(getSortByPreference(), sortBy.toString())
-            appPreferences.setValue(getSortOrderPreference(), sortOrder.toString())
+            appPreferences.setValue(appPreferences.librarySortBy(parentId), sortBy.toString())
+            appPreferences.setValue(appPreferences.librarySortOrder(parentId), sortOrder.toString())
         }
     }
-
-    private fun getSortByPreference(): Preference<String?> =
-        when (libraryType) {
-            CollectionType.Movies -> appPreferences.movieLibrarySortBy
-            CollectionType.TvShows -> appPreferences.tvShowLibrarySortBy
-            else -> appPreferences.otherLibrarySortBy
-        }
-
-    private fun getSortOrderPreference(): Preference<String?> =
-        when (libraryType) {
-            CollectionType.Movies -> appPreferences.movieLibrarySortOrder
-            CollectionType.TvShows -> appPreferences.tvShowLibrarySortOrder
-            else -> appPreferences.otherLibrarySortOrder
-        }
 
     fun onAction(action: LibraryAction) {
         when (action) {

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryViewModel.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/library/LibraryViewModel.kt
@@ -9,6 +9,7 @@ import dev.jdtech.jellyfin.models.SortBy
 import dev.jdtech.jellyfin.models.SortOrder
 import dev.jdtech.jellyfin.repository.JellyfinRepository
 import dev.jdtech.jellyfin.settings.domain.AppPreferences
+import dev.jdtech.jellyfin.settings.domain.models.Preference
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,7 +30,7 @@ constructor(
     lateinit var parentId: UUID
     lateinit var libraryType: CollectionType
 
-    lateinit var sortBy: SortBy
+    lateinit var sortBy: LibrarySortBy
     lateinit var sortOrder: SortOrder
 
     fun setup(parentId: UUID, libraryType: CollectionType) {
@@ -38,23 +39,37 @@ constructor(
     }
 
     fun loadItems() {
-        val itemType =
-            when (libraryType) {
-                CollectionType.Movies -> listOf(BaseItemKind.MOVIE)
-                CollectionType.TvShows -> listOf(BaseItemKind.SERIES)
-                CollectionType.BoxSets -> listOf(BaseItemKind.BOX_SET)
-                CollectionType.Mixed,
-                CollectionType.Folders ->
-                    listOf(BaseItemKind.FOLDER, BaseItemKind.MOVIE, BaseItemKind.SERIES)
-                else -> null
-            }
-
-        val recursive = itemType == null || !itemType.contains(BaseItemKind.FOLDER)
-
         viewModelScope.launch {
             _state.emit(_state.value.copy(isLoading = true, error = null))
 
             initSorting()
+
+            val itemType =
+                when (libraryType) {
+                    CollectionType.Movies -> listOf(BaseItemKind.MOVIE)
+                    CollectionType.TvShows ->
+                        if (sortBy.displaysEpisodes) {
+                            listOf(BaseItemKind.EPISODE)
+                        } else {
+                            listOf(BaseItemKind.SERIES)
+                        }
+                    CollectionType.BoxSets -> listOf(BaseItemKind.BOX_SET)
+                    CollectionType.Mixed,
+                    CollectionType.Folders ->
+                        listOf(BaseItemKind.FOLDER, BaseItemKind.MOVIE, BaseItemKind.SERIES)
+                    else -> null
+                }
+
+            val recursive = itemType == null || !itemType.contains(BaseItemKind.FOLDER)
+            val repositorySortBy =
+                if (
+                    libraryType == CollectionType.TvShows &&
+                        sortBy == LibrarySortBy.DATE_PLAYED
+                ) {
+                    SortBy.SERIES_DATE_PLAYED
+                } else {
+                    sortBy.repositorySortBy
+                }
 
             try {
                 val items =
@@ -63,14 +78,7 @@ constructor(
                             parentId = parentId,
                             includeTypes = itemType,
                             recursive = recursive,
-                            sortBy =
-                                if (
-                                    libraryType == CollectionType.TvShows &&
-                                        sortBy == SortBy.DATE_PLAYED
-                                )
-                                    SortBy.SERIES_DATE_PLAYED
-                                else sortBy, // Jellyfin uses a different enum for sorting series by
-                            // data played
+                            sortBy = repositorySortBy,
                             sortOrder = sortOrder,
                         )
                         .cachedIn(viewModelScope)
@@ -82,27 +90,63 @@ constructor(
     }
 
     private suspend fun initSorting() {
-        if (!::sortBy.isInitialized || !::sortOrder.isInitialized) {
-            sortBy = SortBy.fromString(appPreferences.getValue(appPreferences.sortBy))
-            sortOrder = SortOrder.fromString(appPreferences.getValue(appPreferences.sortOrder))
-            _state.emit(_state.value.copy(sortBy = sortBy, sortOrder = sortOrder))
+        if (::sortBy.isInitialized && ::sortOrder.isInitialized) return
+
+        val sortByPreference = getSortByPreference()
+        val sortOrderPreference = getSortOrderPreference()
+        val savedSortBy = appPreferences.getValue(sortByPreference)
+        val savedSortOrder = appPreferences.getValue(sortOrderPreference)
+
+        sortBy =
+            LibrarySortBy.fromString(
+                savedSortBy ?: appPreferences.getValue(appPreferences.sortBy)
+            )
+        if (sortBy.displaysEpisodes && libraryType != CollectionType.TvShows) {
+            sortBy = LibrarySortBy.defaultValue
+        }
+        sortOrder =
+            SortOrder.fromString(
+                savedSortOrder ?: appPreferences.getValue(appPreferences.sortOrder)
+            )
+
+        _state.emit(_state.value.copy(sortBy = sortBy, sortOrder = sortOrder))
+
+        if (savedSortBy == null) {
+            appPreferences.setValue(sortByPreference, sortBy.toString())
+        }
+        if (savedSortOrder == null) {
+            appPreferences.setValue(sortOrderPreference, sortOrder.toString())
         }
     }
 
-    private fun setSorting(sortBy: SortBy, sortOrder: SortOrder) {
+    private fun setSorting(sortBy: LibrarySortBy, sortOrder: SortOrder) {
         this.sortBy = sortBy
         this.sortOrder = sortOrder
         viewModelScope.launch {
             _state.emit(_state.value.copy(sortBy = sortBy, sortOrder = sortOrder))
-            appPreferences.setValue(appPreferences.sortBy, sortBy.toString())
-            appPreferences.setValue(appPreferences.sortOrder, sortOrder.toString())
+            appPreferences.setValue(getSortByPreference(), sortBy.toString())
+            appPreferences.setValue(getSortOrderPreference(), sortOrder.toString())
         }
     }
+
+    private fun getSortByPreference(): Preference<String?> =
+        when (libraryType) {
+            CollectionType.Movies -> appPreferences.movieLibrarySortBy
+            CollectionType.TvShows -> appPreferences.tvShowLibrarySortBy
+            else -> appPreferences.otherLibrarySortBy
+        }
+
+    private fun getSortOrderPreference(): Preference<String?> =
+        when (libraryType) {
+            CollectionType.Movies -> appPreferences.movieLibrarySortOrder
+            CollectionType.TvShows -> appPreferences.tvShowLibrarySortOrder
+            else -> appPreferences.otherLibrarySortOrder
+        }
 
     fun onAction(action: LibraryAction) {
         when (action) {
             is LibraryAction.ChangeSorting -> {
-                if (action.sortBy != this.sortBy || action.sortOrder != this.sortOrder) {
+                if (action.sortBy != sortBy || action.sortOrder != sortOrder) {
                     setSorting(sortBy = action.sortBy, sortOrder = action.sortOrder)
                     loadItems()
                 }

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
@@ -96,8 +96,15 @@ class AppPreferences @Inject constructor(val sharedPreferences: SharedPreference
     val imageCacheSize = Preference("pref_image_cache_size", 20)
 
     // Sorting
+    // Legacy global preferences are retained to initialize the per-library preferences.
     val sortBy = Preference("pref_sort_by", "SortName")
     val sortOrder = Preference("pref_sort_order", "Ascending")
+    val movieLibrarySortBy = Preference<String?>("pref_movie_library_sort_by", null)
+    val movieLibrarySortOrder = Preference<String?>("pref_movie_library_sort_order", null)
+    val tvShowLibrarySortBy = Preference<String?>("pref_tv_show_library_sort_by", null)
+    val tvShowLibrarySortOrder = Preference<String?>("pref_tv_show_library_sort_order", null)
+    val otherLibrarySortBy = Preference<String?>("pref_other_library_sort_by", null)
+    val otherLibrarySortOrder = Preference<String?>("pref_other_library_sort_order", null)
 
     // Offline mode
     val offlineMode = Preference("pref_offline_mode", false)

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
@@ -2,6 +2,7 @@ package dev.jdtech.jellyfin.settings.domain
 
 import android.content.SharedPreferences
 import dev.jdtech.jellyfin.settings.domain.models.Preference
+import java.util.UUID
 import javax.inject.Inject
 import timber.log.Timber
 
@@ -99,12 +100,12 @@ class AppPreferences @Inject constructor(val sharedPreferences: SharedPreference
     // Legacy global preferences are retained to initialize the per-library preferences.
     val sortBy = Preference("pref_sort_by", "SortName")
     val sortOrder = Preference("pref_sort_order", "Ascending")
-    val movieLibrarySortBy = Preference<String?>("pref_movie_library_sort_by", null)
-    val movieLibrarySortOrder = Preference<String?>("pref_movie_library_sort_order", null)
-    val tvShowLibrarySortBy = Preference<String?>("pref_tv_show_library_sort_by", null)
-    val tvShowLibrarySortOrder = Preference<String?>("pref_tv_show_library_sort_order", null)
-    val otherLibrarySortBy = Preference<String?>("pref_other_library_sort_by", null)
-    val otherLibrarySortOrder = Preference<String?>("pref_other_library_sort_order", null)
+
+    fun librarySortBy(libraryId: UUID) =
+        Preference<String?>("pref_library_${libraryId}_sort_by", null)
+
+    fun librarySortOrder(libraryId: UUID) =
+        Preference<String?>("pref_library_${libraryId}_sort_order", null)
 
     // Offline mode
     val offlineMode = Preference("pref_offline_mode", false)


### PR DESCRIPTION
## Summary

- let users browse individual episodes in TV show libraries, ordered either by when they were added or by original air date
- display episode results as landscape cards with the show title, season and episode numbers, and episode title
- persist the selected sorting independently for each library
- support the new sorting options on phone and TV

## Testing

- `./gradlew ktfmtCheck :app:phone:assembleLibreDebug :app:tv:assembleLibreDebug`
