### PR TITLE
fix(downloads): keep downloaded items reachable when the server loses them

### DIFF
--- a/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/repository/JellyfinRepositoryImpl.kt
@@ -71,34 +71,52 @@ class JellyfinRepositoryImpl(
 
     override suspend fun getEpisode(itemId: UUID): FindroidEpisode =
         withContext(Dispatchers.IO) {
-            jellyfinApi.userLibraryApi
-                .getItem(itemId, jellyfinApi.userId!!)
-                .content
-                .toFindroidEpisode(this@JellyfinRepositoryImpl, database)!!
+            try {
+                jellyfinApi.userLibraryApi
+                    .getItem(itemId, jellyfinApi.userId!!)
+                    .content
+                    .toFindroidEpisode(this@JellyfinRepositoryImpl, database)!!
+            } catch (e: Exception) {
+                // Downloaded, but the server no longer has it. Without this the screen never
+                // loads, and since delete lives on that screen the copy on disk is stranded.
+                downloadedEpisode(itemId) ?: throw e
+            }
         }
 
     override suspend fun getMovie(itemId: UUID): FindroidMovie =
         withContext(Dispatchers.IO) {
-            jellyfinApi.userLibraryApi
-                .getItem(itemId, jellyfinApi.userId!!)
-                .content
-                .toFindroidMovie(this@JellyfinRepositoryImpl, database)
+            try {
+                jellyfinApi.userLibraryApi
+                    .getItem(itemId, jellyfinApi.userId!!)
+                    .content
+                    .toFindroidMovie(this@JellyfinRepositoryImpl, database)
+            } catch (e: Exception) {
+                downloadedMovie(itemId) ?: throw e
+            }
         }
 
     override suspend fun getShow(itemId: UUID): FindroidShow =
         withContext(Dispatchers.IO) {
-            jellyfinApi.userLibraryApi
-                .getItem(itemId, jellyfinApi.userId!!)
-                .content
-                .toFindroidShow(this@JellyfinRepositoryImpl)
+            try {
+                jellyfinApi.userLibraryApi
+                    .getItem(itemId, jellyfinApi.userId!!)
+                    .content
+                    .toFindroidShow(this@JellyfinRepositoryImpl)
+            } catch (e: Exception) {
+                downloadedShow(itemId) ?: throw e
+            }
         }
 
     override suspend fun getSeason(itemId: UUID): FindroidSeason =
         withContext(Dispatchers.IO) {
-            jellyfinApi.userLibraryApi
-                .getItem(itemId, jellyfinApi.userId!!)
-                .content
-                .toFindroidSeason(this@JellyfinRepositoryImpl)
+            try {
+                jellyfinApi.userLibraryApi
+                    .getItem(itemId, jellyfinApi.userId!!)
+                    .content
+                    .toFindroidSeason(this@JellyfinRepositoryImpl)
+            } catch (e: Exception) {
+                downloadedSeason(itemId) ?: throw e
+            }
         }
 
     override suspend fun getLibraries(): List<FindroidCollection> =
@@ -284,18 +302,43 @@ class JellyfinRepositoryImpl(
     ): List<FindroidEpisode> =
         withContext(Dispatchers.IO) {
             if (!offline) {
-                jellyfinApi.showsApi
-                    .getEpisodes(
-                        seriesId,
-                        jellyfinApi.userId!!,
-                        seasonId = seasonId,
-                        fields = fields,
-                        startItemId = startItemId,
-                        limit = limit,
-                    )
-                    .content
-                    .items
-                    .mapNotNull { it.toFindroidEpisode(this@JellyfinRepositoryImpl, database) }
+                // Anything downloaded from this season that the server no longer lists: the
+                // season being gone entirely, or just one episode removed from it. Without
+                // these the copy on disk cannot be reached, and delete lives on its screen.
+                val downloaded =
+                    database.getEpisodesBySeasonId(seasonId).map {
+                        it.toFindroidEpisode(database, jellyfinApi.userId!!)
+                    }
+                val fromServer =
+                    try {
+                        jellyfinApi.showsApi
+                            .getEpisodes(
+                                seriesId,
+                                jellyfinApi.userId!!,
+                                seasonId = seasonId,
+                                fields = fields,
+                                startItemId = startItemId,
+                                limit = limit,
+                            )
+                            .content
+                            .items
+                            .mapNotNull {
+                                it.toFindroidEpisode(this@JellyfinRepositoryImpl, database)
+                            }
+                    } catch (e: Exception) {
+                        // The whole season is gone from the server. Fall back to what was
+                        // downloaded from it, but only when there is something: with nothing to
+                        // show, the error is the honest answer, and swallowing it would turn an
+                        // outage into a season that looks empty rather than unreachable.
+                        //
+                        // Deliberately not narrowed by status code. The server answers 404 for an
+                        // item it deleted but 500 for an id it has no record of, and which one a
+                        // removed season produces depends on how it was removed.
+                        if (downloaded.isEmpty()) throw e
+                        emptyList()
+                    }
+                val known = fromServer.mapTo(mutableSetOf()) { it.id }
+                (fromServer + downloaded.filterNot { it.id in known }).sortedBy { it.indexNumber }
             } else {
                 database.getEpisodesBySeasonId(seasonId).map {
                     it.toFindroidEpisode(database, jellyfinApi.userId!!)
@@ -567,6 +610,24 @@ class JellyfinRepositoryImpl(
             )
             items
         }
+
+    /**
+     * The downloaded copy of an item the server has since lost, or null if there is none. Room
+     * throws rather than returning null for a missing row, hence the catch.
+     */
+    private fun downloadedEpisode(itemId: UUID): FindroidEpisode? =
+        runCatching { database.getEpisode(itemId).toFindroidEpisode(database, getUserId()) }
+            .getOrNull()
+
+    private fun downloadedMovie(itemId: UUID): FindroidMovie? =
+        runCatching { database.getMovie(itemId).toFindroidMovie(database, getUserId()) }.getOrNull()
+
+    private fun downloadedShow(itemId: UUID): FindroidShow? =
+        runCatching { database.getShow(itemId).toFindroidShow(database, getUserId()) }.getOrNull()
+
+    private fun downloadedSeason(itemId: UUID): FindroidSeason? =
+        runCatching { database.getSeason(itemId).toFindroidSeason(database, getUserId()) }
+            .getOrNull()
 
     override fun getUserId(): UUID {
         return jellyfinApi.userId!!


### PR DESCRIPTION
## Problem

An item that has been downloaded and is later removed from the server becomes
unusable and unremovable.

Opening it fails, because every lookup goes straight to the API and the error
propagates to the screen. And since deleting a download is done from that same
screen, the copy on disk cannot be reached to delete it either. It stays there
taking up space with nothing in the app able to touch it — on one device this
had accumulated several gigabytes.

A season shows the same thing in a smaller way: an episode that was downloaded
and has since been removed from the server simply disappears from the list,
because the list is built purely from what the server returns.

## Fix

- `getEpisode`, `getMovie`, `getShow` and `getSeason` fall back to the
  downloaded copy when the server lookup fails, so the screen still opens and
  delete is reachable.
- `getEpisodes` merges what the server lists with anything downloaded from that
  season that it no longer lists. This is what covers a single removed episode:
  the server answers that request perfectly well, just without the episode in
  it, so a fallback would never fire and only a merge helps.

The single-item fallbacks catch broadly on purpose — they only engage when a
downloaded copy exists, and the alternative is a dead screen. The season merge
is deliberately stricter: it rethrows unless something was downloaded, so a
network failure still surfaces as an error instead of a season that looks
empty.

## Why it is not narrowed to a 404

Checking the status code seems like the obvious tightening, but measured
against Jellyfin 10.11.x it breaks the fix:

| case | response |
|---|---|
| item the server deleted | `404` |
| id the server never knew | `500` |
| live season, one episode removed | `200`, episode simply absent |
| season emptied of all items | `200`, zero items |

Narrowing to 404 would miss the 500 case, and narrowing to 500 would miss the
404 one. Which of the two a removed item produces depends on how it was
removed, so the catch stays broad and is bounded by "only when a downloaded
copy exists" instead. There is a comment in the code saying so, so it is not
"tidied up" later.

## Testing

Verified end to end against a real Jellyfin server by downloading an episode,
deleting it server side, and rescanning until the server returned 404 for it:

- the season lists the episode again, with its downloaded badge
- its screen opens instead of failing
- delete works, and removes the source row, the item rows and the file
- the season then shows the remaining episodes with no phantom left behind

The whole-season case was tested the same way by emptying the season, and the
merge covers it because the server keeps the season shell and returns zero
items rather than an error.

## Scope

One file, no new dependencies, no schema change, and no behaviour change for
items the server still has — the fallbacks only run when a lookup fails or when
a downloaded item is missing from a list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
