### PR TITLE
Add an optional sequential download setting

### DIFF
--- a/app/phone/src/main/AndroidManifest.xml
+++ b/app/phone/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <uses-feature
         android:name="android.hardware.wifi"
@@ -42,6 +44,11 @@
             </intent-filter>
 
         </activity>
+
+        <service
+            android:name=".utils.DownloadForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
 
         <receiver
             android:name=".utils.DownloadReceiver"

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/BaseApplication.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/BaseApplication.kt
@@ -23,6 +23,7 @@ import coil3.svg.SvgDecoder
 import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.HiltAndroidApp
 import dev.jdtech.jellyfin.settings.domain.AppPreferences
+import dev.jdtech.jellyfin.utils.DownloadQueue
 import dev.jdtech.jellyfin.work.MpvCleanupWorker
 import dev.jdtech.jellyfin.work.SyncWorker
 import javax.inject.Inject
@@ -35,6 +36,8 @@ class BaseApplication : Application(), Configuration.Provider, SingletonImageLoa
     @Inject lateinit var appPreferences: AppPreferences
 
     @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject lateinit var downloadQueue: DownloadQueue
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder().setWorkerFactory(workerFactory).build()
@@ -62,6 +65,10 @@ class BaseApplication : Application(), Configuration.Provider, SingletonImageLoa
         }
 
         val workManager = WorkManager.getInstance(applicationContext)
+
+        // Picks a queue left by a previous run back up. Cheap when there is nothing queued: it
+        // reads one empty table and stops.
+        downloadQueue.resume()
 
         scheduleUserDataSync(workManager)
 

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/SeasonScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/SeasonScreen.kt
@@ -35,11 +35,15 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.jdtech.jellyfin.PlayerActivity
+import dev.jdtech.jellyfin.core.presentation.downloader.DownloaderAction
+import dev.jdtech.jellyfin.core.presentation.downloader.DownloaderState
+import dev.jdtech.jellyfin.core.presentation.downloader.DownloaderViewModel
 import dev.jdtech.jellyfin.core.presentation.dummy.dummySeason
 import dev.jdtech.jellyfin.film.presentation.season.SeasonAction
 import dev.jdtech.jellyfin.film.presentation.season.SeasonState
 import dev.jdtech.jellyfin.film.presentation.season.SeasonViewModel
 import dev.jdtech.jellyfin.models.FindroidItem
+import dev.jdtech.jellyfin.models.isDownloaded
 import dev.jdtech.jellyfin.presentation.film.components.Direction
 import dev.jdtech.jellyfin.presentation.film.components.EpisodeCard
 import dev.jdtech.jellyfin.presentation.film.components.ItemButtonsBar
@@ -49,6 +53,7 @@ import dev.jdtech.jellyfin.presentation.film.components.ItemTopBar
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.presentation.utils.rememberSafePadding
+import dev.jdtech.jellyfin.utils.ObserveAsEvents
 import java.util.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
 
@@ -60,14 +65,23 @@ fun SeasonScreen(
     navigateToItem: (item: FindroidItem) -> Unit,
     navigateToSeries: (seriesId: UUID) -> Unit,
     viewModel: SeasonViewModel = hiltViewModel(),
+    downloaderViewModel: DownloaderViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val downloaderState by downloaderViewModel.state.collectAsStateWithLifecycle()
 
     LaunchedEffect(true) { viewModel.loadSeason(seasonId = seasonId) }
 
+    ObserveAsEvents(downloaderViewModel.events) {
+        // As episodes are downloaded, reload season to render
+        // the download badges
+        viewModel.loadSeason(seasonId = seasonId)
+    }
+
     SeasonScreenLayout(
         state = state,
+        downloaderState = downloaderState,
         onAction = { action ->
             when (action) {
                 is SeasonAction.Play -> {
@@ -84,11 +98,17 @@ fun SeasonScreen(
             }
             viewModel.onAction(action)
         },
+        onDownloaderAction = { action -> downloaderViewModel.onAction(action) },
     )
 }
 
 @Composable
-private fun SeasonScreenLayout(state: SeasonState, onAction: (SeasonAction) -> Unit) {
+private fun SeasonScreenLayout(
+    state: SeasonState,
+    downloaderState: DownloaderState,
+    onAction: (SeasonAction) -> Unit,
+    onDownloaderAction: (DownloaderAction) -> Unit,
+) {
     val safePadding = rememberSafePadding()
 
     val paddingStart = safePadding.start + MaterialTheme.spacings.default
@@ -141,8 +161,17 @@ private fun SeasonScreenLayout(state: SeasonState, onAction: (SeasonAction) -> U
                         },
                     )
                     Spacer(Modifier.height(MaterialTheme.spacings.default.div(2)))
+                    // Using any because we want the delete button to be visible if ANY episode
+                    // in the season has been downloaded
+                    val isSeasonDownloaded = state.episodes.any { it.isDownloaded() }
+                    // Only want to show the download button if any episodes still haven't
+                    // been downloaded
+                    val canSeasonBeDownloaded = state.episodes.any { it.canDownload } && !state.episodes.all { it.isDownloaded() }
                     ItemButtonsBar(
                         item = season,
+                        downloaderState = downloaderState,
+                        isItemDownloaded = isSeasonDownloaded,
+                        canDownload = canSeasonBeDownloaded,
                         onPlayClick = { startFromBeginning ->
                             onAction(SeasonAction.Play(startFromBeginning = startFromBeginning))
                         },
@@ -159,9 +188,21 @@ private fun SeasonScreenLayout(state: SeasonState, onAction: (SeasonAction) -> U
                             }
                         },
                         onTrailerClick = {},
-                        onDownloadClick = {},
-                        onDownloadCancelClick = {},
-                        onDownloadDeleteClick = {},
+                        onDownloadClick = { storageIndex ->
+                            onDownloaderAction(
+                                DownloaderAction.DownloadMany(state.episodes, storageIndex)
+                            )
+                        },
+                        onDownloadCancelClick = {
+                            onDownloaderAction(
+                                DownloaderAction.CancelDownloadMany
+                            )
+                        },
+                        onDownloadDeleteClick = {
+                            onDownloaderAction(
+                                DownloaderAction.DeleteDownloadMany(state.episodes)
+                            )
+                        },
                         modifier =
                             Modifier.padding(start = paddingStart, end = paddingEnd).fillMaxWidth(),
                         canPlay = state.episodes.isNotEmpty(),
@@ -204,5 +245,12 @@ private fun SeasonScreenLayout(state: SeasonState, onAction: (SeasonAction) -> U
 @PreviewScreenSizes
 @Composable
 private fun SeasonScreenLayoutPreview() {
-    FindroidTheme { SeasonScreenLayout(state = SeasonState(season = dummySeason), onAction = {}) }
+    FindroidTheme {
+        SeasonScreenLayout(
+            state = SeasonState(season = dummySeason),
+            downloaderState = DownloaderState(),
+            onAction = {},
+            onDownloaderAction = {},
+        )
+    }
 }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/SeasonScreen.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/SeasonScreen.kt
@@ -46,6 +46,7 @@ import dev.jdtech.jellyfin.models.FindroidItem
 import dev.jdtech.jellyfin.models.isDownloaded
 import dev.jdtech.jellyfin.presentation.film.components.Direction
 import dev.jdtech.jellyfin.presentation.film.components.EpisodeCard
+import dev.jdtech.jellyfin.utils.DownloadEntry
 import dev.jdtech.jellyfin.presentation.film.components.ItemButtonsBar
 import dev.jdtech.jellyfin.presentation.film.components.ItemHeader
 import dev.jdtech.jellyfin.presentation.film.components.ItemPoster
@@ -70,6 +71,8 @@ fun SeasonScreen(
     val context = LocalContext.current
     val state by viewModel.state.collectAsStateWithLifecycle()
     val downloaderState by downloaderViewModel.state.collectAsStateWithLifecycle()
+    // So an episode waiting its turn says so in the list, rather than only on its own screen.
+    val queue by downloaderViewModel.queue.collectAsStateWithLifecycle()
 
     LaunchedEffect(true) { viewModel.loadSeason(seasonId = seasonId) }
 
@@ -82,6 +85,7 @@ fun SeasonScreen(
     SeasonScreenLayout(
         state = state,
         downloaderState = downloaderState,
+        downloadEntries = queue.entries.associateBy { it.itemId },
         onAction = { action ->
             when (action) {
                 is SeasonAction.Play -> {
@@ -106,6 +110,7 @@ fun SeasonScreen(
 private fun SeasonScreenLayout(
     state: SeasonState,
     downloaderState: DownloaderState,
+    downloadEntries: Map<UUID, DownloadEntry>,
     onAction: (SeasonAction) -> Unit,
     onDownloaderAction: (DownloaderAction) -> Unit,
 ) {
@@ -212,6 +217,7 @@ private fun SeasonScreenLayout(
                     EpisodeCard(
                         episode = episode,
                         onClick = { onAction(SeasonAction.NavigateToItem(episode)) },
+                        downloadEntry = downloadEntries[episode.id],
                         modifier = Modifier.padding(start = paddingStart, end = paddingEnd),
                     )
                 }
@@ -249,6 +255,7 @@ private fun SeasonScreenLayoutPreview() {
         SeasonScreenLayout(
             state = SeasonState(season = dummySeason),
             downloaderState = DownloaderState(),
+            downloadEntries = emptyMap(),
             onAction = {},
             onDownloaderAction = {},
         )

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/DownloaderCard.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/DownloaderCard.kt
@@ -38,9 +38,8 @@ import kotlin.math.roundToInt
 
 @Composable
 fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryClick: () -> Unit) {
-    // Null means the total size is unknown, which is always so for a transcode: the server makes
-    // it on the fly and sends no Content-Length. There is no percentage to draw, so the bar goes
-    // indeterminate and the byte count stands in for it.
+    // Null means the server reported no total size, so there is no percentage to draw: the bar
+    // goes indeterminate and the byte count stands in for it.
     val progress = state.progress
     val animatedProgress by
         animateFloatAsState(
@@ -89,8 +88,7 @@ fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryCli
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.medium),
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                // Local vals: DownloaderState lives in another module, so its nullable properties
-                // cannot be smart cast here.
+                // Local vals: DownloaderState is in another module, so no smart cast here.
                 val itemsTotal = state.itemsTotal
                 val itemsCompleted = state.itemsCompleted
                 val counter =
@@ -133,9 +131,8 @@ fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryCli
                 }
                 Spacer(Modifier.height(MaterialTheme.spacings.small))
                 when {
-                    // A bar pinned at zero reads as a stalled download, so anything still moving
-                    // without a known total gets the indeterminate one instead. A paused download
-                    // keeps the static bar: it is not moving, and the label already says so.
+                    // A bar pinned at zero reads as stalled, so anything moving without a known
+                    // total gets the indeterminate one. Paused keeps the static bar.
                     state.status == DownloadManager.STATUS_PENDING ||
                         (progress == null && state.status == DownloadManager.STATUS_RUNNING) -> {
                         LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
@@ -162,8 +159,7 @@ fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryCli
                 when (state.status) {
                     DownloadManager.STATUS_PENDING,
                     DownloadManager.STATUS_RUNNING,
-                    // A paused download holds up the whole sequential queue, so it has to stay
-                    // cancellable — the item buttons row is hidden while the card is mounted.
+                    // A paused download holds up the queue, so it has to stay cancellable.
                     DownloadManager.STATUS_PAUSED -> {
                         FilledTonalIconButton(onClick = onCancelClick) {
                             Icon(

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/DownloaderCard.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/DownloaderCard.kt
@@ -1,6 +1,7 @@
 package dev.jdtech.jellyfin.presentation.film.components
 
 import android.app.DownloadManager
+import android.text.format.Formatter
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,7 +22,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,11 +38,21 @@ import kotlin.math.roundToInt
 
 @Composable
 fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryClick: () -> Unit) {
+    // Null means the total size is unknown, which is always so for a transcode: the server makes
+    // it on the fly and sends no Content-Length. There is no percentage to draw, so the bar goes
+    // indeterminate and the byte count stands in for it.
+    val progress = state.progress
     val animatedProgress by
         animateFloatAsState(
-            targetValue = state.progress,
+            targetValue = progress ?: 0f,
             animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
         )
+    val downloadedText =
+        if (progress == null && state.bytesDownloaded > 0) {
+            Formatter.formatShortFileSize(LocalContext.current, state.bytesDownloaded)
+        } else {
+            null
+        }
 
     val textColor =
         when (state.status) {
@@ -76,24 +89,55 @@ fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryCli
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.medium),
         ) {
             Column(modifier = Modifier.weight(1f)) {
+                // Local vals: DownloaderState lives in another module, so its nullable properties
+                // cannot be smart cast here.
+                val itemsTotal = state.itemsTotal
+                val itemsCompleted = state.itemsCompleted
+                val counter =
+                    if (itemsTotal != null && itemsCompleted != null) "$itemsCompleted/$itemsTotal"
+                    else null
+
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    Text(
-                        text = statusText,
-                        color = textColor,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Text(
-                        text = animatedProgress.times(100).roundToInt().toString() + "%",
-                        color = textColor,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.small)) {
+                        Text(
+                            text = statusText,
+                            color = textColor,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        if (counter != null) {
+                            Text(
+                                text = counter,
+                                modifier = Modifier.alpha(0.7f),
+                                color = textColor,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+                    when {
+                        progress != null ->
+                            Text(
+                                text = animatedProgress.times(100).roundToInt().toString() + "%",
+                                color = textColor,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        downloadedText != null ->
+                            Text(
+                                text = downloadedText,
+                                color = textColor,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                    }
                 }
                 Spacer(Modifier.height(MaterialTheme.spacings.small))
-                when (state.status) {
-                    DownloadManager.STATUS_PENDING -> {
+                when {
+                    // A bar pinned at zero reads as a stalled download, so anything still moving
+                    // without a known total gets the indeterminate one instead. A paused download
+                    // keeps the static bar: it is not moving, and the label already says so.
+                    state.status == DownloadManager.STATUS_PENDING ||
+                        (progress == null && state.status == DownloadManager.STATUS_RUNNING) -> {
                         LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                     }
                     else -> {
@@ -117,7 +161,10 @@ fun DownloaderCard(state: DownloaderState, onCancelClick: () -> Unit, onRetryCli
             CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
                 when (state.status) {
                     DownloadManager.STATUS_PENDING,
-                    DownloadManager.STATUS_RUNNING -> {
+                    DownloadManager.STATUS_RUNNING,
+                    // A paused download holds up the whole sequential queue, so it has to stay
+                    // cancellable — the item buttons row is hidden while the card is mounted.
+                    DownloadManager.STATUS_PAUSED -> {
                         FilledTonalIconButton(onClick = onCancelClick) {
                             Icon(
                                 painter = painterResource(CoreR.drawable.ic_x),
@@ -157,6 +204,43 @@ private fun DownloaderCardDownloadingPreview() {
     FindroidTheme {
         DownloaderCard(
             state = DownloaderState(status = DownloadManager.STATUS_RUNNING, progress = 0.5f),
+            onCancelClick = {},
+            onRetryClick = {},
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun DownloaderCardBatchPreview() {
+    FindroidTheme {
+        DownloaderCard(
+            state =
+                DownloaderState(
+                    status = DownloadManager.STATUS_RUNNING,
+                    progress = 0.84f,
+                    itemsCompleted = 3,
+                    itemsTotal = 13,
+                ),
+            onCancelClick = {},
+            onRetryClick = {},
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun DownloaderCardUnknownSizePreview() {
+    FindroidTheme {
+        DownloaderCard(
+            state =
+                DownloaderState(
+                    status = DownloadManager.STATUS_RUNNING,
+                    progress = null,
+                    bytesDownloaded = 533_725_184,
+                    itemsCompleted = 1,
+                    itemsTotal = 10,
+                ),
             onCancelClick = {},
             onRetryClick = {},
         )

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/DownloadingBadge.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/DownloadingBadge.kt
@@ -1,0 +1,51 @@
+package dev.jdtech.jellyfin.presentation.film.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
+
+/**
+ * Marks the episode the queue is currently working on. Indeterminate while the item is still
+ * waiting its turn or starting, determinate once DownloadManager reports real progress.
+ */
+@Composable
+fun DownloadingBadge(progress: Float?, modifier: Modifier = Modifier) {
+    BaseBadge(modifier = modifier) {
+        val indicatorModifier =
+            Modifier.size(16.dp).align(Alignment.Center).padding(0.dp)
+        if (progress == null) {
+            CircularProgressIndicator(
+                modifier = indicatorModifier,
+                color = MaterialTheme.colorScheme.onPrimary,
+                strokeWidth = 2.dp,
+            )
+        } else {
+            CircularProgressIndicator(
+                progress = { progress },
+                modifier = indicatorModifier,
+                color = MaterialTheme.colorScheme.onPrimary,
+                trackColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f),
+                strokeWidth = 2.dp,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun DownloadingBadgeIndeterminatePreview() {
+    FindroidTheme { DownloadingBadge(progress = null) }
+}
+
+@Composable
+@Preview
+private fun DownloadingBadgeProgressPreview() {
+    FindroidTheme { DownloadingBadge(progress = 0.42f) }
+}

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/EpisodeCard.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/EpisodeCard.kt
@@ -1,5 +1,6 @@
 package dev.jdtech.jellyfin.presentation.film.components
 
+import android.text.format.Formatter
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -21,19 +22,52 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.jdtech.jellyfin.core.presentation.dummy.dummyEpisode
+import dev.jdtech.jellyfin.core.R as CoreR
 import dev.jdtech.jellyfin.models.FindroidEpisode
+import dev.jdtech.jellyfin.utils.DownloadEntry
+import dev.jdtech.jellyfin.utils.DownloadEntryStatus
 import dev.jdtech.jellyfin.models.isDownloaded
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 
 @Composable
-fun EpisodeCard(episode: FindroidEpisode, onClick: () -> Unit, modifier: Modifier = Modifier) {
+fun EpisodeCard(
+    episode: FindroidEpisode,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    /** This episode's place in the download queue, when it is in one. */
+    downloadEntry: DownloadEntry? = null,
+) {
     val backgroundColor = MaterialTheme.colorScheme.background
+    val activeEntry = downloadEntry?.takeIf { !it.status.isTerminal }
+    val statusText =
+        when (activeEntry?.status) {
+            DownloadEntryStatus.QUEUED -> stringResource(CoreR.string.download_queued)
+            DownloadEntryStatus.PAUSED -> stringResource(CoreR.string.download_paused)
+            DownloadEntryStatus.PREPARING -> stringResource(CoreR.string.download_pending)
+            DownloadEntryStatus.RUNNING ->
+                when {
+                    activeEntry.progress >= 0 ->
+                        stringResource(CoreR.string.download_progress, activeEntry.progress)
+                    // No total size to compute a percentage from, so report what has arrived.
+                    activeEntry.bytesDownloaded > 0 ->
+                        stringResource(
+                            CoreR.string.download_downloading_size,
+                            Formatter.formatShortFileSize(
+                                LocalContext.current,
+                                activeEntry.bytesDownloaded,
+                            ),
+                        )
+                    else -> stringResource(CoreR.string.download_downloading)
+                }
+            else -> null
+        }
 
     Row(
         modifier =
@@ -53,7 +87,16 @@ fun EpisodeCard(episode: FindroidEpisode, onClick: () -> Unit, modifier: Modifie
                 modifier = Modifier.align(Alignment.TopEnd).padding(MaterialTheme.spacings.small),
                 horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacings.small),
             ) {
-                if (episode.isDownloaded()) DownloadedBadge()
+                if (activeEntry != null) {
+                    DownloadingBadge(
+                        progress =
+                            activeEntry.progress
+                                .takeIf {
+                                    it >= 0 && activeEntry.status == DownloadEntryStatus.RUNNING
+                                }
+                                ?.div(100f)
+                    )
+                } else if (episode.isDownloaded()) DownloadedBadge()
                 if (episode.played) PlayedBadge()
             }
         }
@@ -71,6 +114,14 @@ fun EpisodeCard(episode: FindroidEpisode, onClick: () -> Unit, modifier: Modifie
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.bodyMedium,
                 )
+                if (statusText != null) {
+                    Text(
+                        text = statusText,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
                 Text(
                     text = episode.overview,
                     modifier = Modifier.alpha(0.7f),

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/ItemButtonsBar.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/film/components/ItemButtonsBar.kt
@@ -51,6 +51,12 @@ fun ItemButtonsBar(
     onTrailerClick: (uri: String) -> Unit,
     modifier: Modifier = Modifier,
     downloaderState: DownloaderState? = null,
+    // Used by seasons, episodes are loaded in the state and are used to
+    // determine this. Combined with item
+    isItemDownloaded: Boolean = false,
+    // Used by seasons, episodes are loaded in the state and are used to
+    // determine this. Combined with item.
+    canDownload: Boolean = false,
     canPlay: Boolean = true,
 ) {
     val context = LocalContext.current
@@ -154,14 +160,19 @@ fun ItemButtonsBar(
                     }
                 }
                 if (downloaderState != null && !downloaderState.isDownloading) {
-                    if (item.isDownloaded()) {
+                    // Render both Delete and Download buttons for seasons, which may have
+                    // some episodes downloaded and some not.
+                    if (isItemDownloaded || item.isDownloaded()) {
                         FilledTonalIconButton(onClick = { deleteDownloadDialogOpen = true }) {
                             Icon(
                                 painter = painterResource(CoreR.drawable.ic_trash),
                                 contentDescription = null,
                             )
                         }
-                    } else if (item.canDownload) {
+                    }
+                    // canDownload is for seasons. Else, an item should only render the download
+                    // button if item is not downloaded.
+                    if (canDownload || (item.canDownload && !item.isDownloaded())) {
                         FilledTonalIconButton(
                             onClick = {
                                 storageLocations = context.getExternalFilesDirs(null)
@@ -245,6 +256,7 @@ private fun ItemButtonsBarPreview() {
         ItemButtonsBar(
             item = dummyEpisode,
             onPlayClick = {},
+            canDownload = true,
             onMarkAsPlayedClick = {},
             onMarkAsFavoriteClick = {},
             onDownloadClick = {},
@@ -263,6 +275,7 @@ private fun ItemButtonsBarDownloadingPreview() {
             item = dummyEpisode,
             downloaderState =
                 DownloaderState(status = DownloadManager.STATUS_RUNNING, progress = 0.3f),
+            canDownload = true,
             onPlayClick = {},
             onMarkAsPlayedClick = {},
             onMarkAsFavoriteClick = {},

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,6 +27,10 @@ android {
     }
 
     buildFeatures { compose = true }
+
+    // The queue is exercised with fakes rather than a device, so the android.* calls it makes
+    // need to return defaults instead of throwing.
+    testOptions { unitTests { isReturnDefaultValues = true } }
 }
 
 dependencies {
@@ -50,4 +54,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.slf4j.api)
     implementation(libs.slf4j.android)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderAction.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderAction.kt
@@ -5,7 +5,13 @@ import dev.jdtech.jellyfin.models.FindroidItem
 sealed interface DownloaderAction {
     data class Download(val item: FindroidItem, val storageIndex: Int = 0) : DownloaderAction
 
+    data class DownloadMany(val items: List<FindroidItem>, val storageIndex: Int = 0) : DownloaderAction
+
     data class DeleteDownload(val item: FindroidItem) : DownloaderAction
 
+    data class DeleteDownloadMany(val items: List<FindroidItem>) : DownloaderAction
+
     data class CancelDownload(val item: FindroidItem) : DownloaderAction
+
+    data object CancelDownloadMany: DownloaderAction
 }

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderState.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderState.kt
@@ -5,15 +5,32 @@ import dev.jdtech.jellyfin.models.UiText
 
 data class DownloaderState(
     val status: Int = 0,
-    val progress: Float = 0f,
+    /**
+     * For a batch this is the progress of the item currently downloading, not of the batch. Null
+     * means there is no percentage to show: a transcode is generated on the fly and served without
+     * a Content-Length, so the total size is unknown for the whole download.
+     */
+    val progress: Float? = 0f,
+    /** Bytes fetched so far. Shown in place of a percentage when [progress] is null. */
+    val bytesDownloaded: Long = 0,
     val errorText: UiText? = null,
+    /** 1-based position of the item being downloaded; null for a single item download. */
+    val itemsCompleted: Int? = null,
+    /** Size of the batch; null for a single item download. */
+    val itemsTotal: Int? = null,
 ) {
+    /**
+     * Really means "keep the downloader card mounted". STATUS_FAILED is in here because the card
+     * carries the error text and the retry button, and STATUS_PAUSED because a paused download
+     * holds up the whole sequential queue and so has to stay visible and cancellable.
+     */
     val isDownloading: Boolean
         get() =
             status in
                 arrayOf(
                     DownloadManager.STATUS_PENDING,
                     DownloadManager.STATUS_RUNNING,
+                    DownloadManager.STATUS_PAUSED,
                     DownloadManager.STATUS_FAILED,
                 )
 }

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderState.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderState.kt
@@ -5,24 +5,19 @@ import dev.jdtech.jellyfin.models.UiText
 
 data class DownloaderState(
     val status: Int = 0,
-    /**
-     * For a batch this is the progress of the item currently downloading, not of the batch. Null
-     * means there is no percentage to show: a transcode is generated on the fly and served without
-     * a Content-Length, so the total size is unknown for the whole download.
-     */
+    /** Progress of the item downloading now, or null when the server reported no total size. */
     val progress: Float? = 0f,
-    /** Bytes fetched so far. Shown in place of a percentage when [progress] is null. */
+    /** Shown in place of a percentage when [progress] is null. */
     val bytesDownloaded: Long = 0,
     val errorText: UiText? = null,
-    /** 1-based position of the item being downloaded; null for a single item download. */
+    /** 1-based position within the batch; null when only one item was asked for. */
     val itemsCompleted: Int? = null,
-    /** Size of the batch; null for a single item download. */
     val itemsTotal: Int? = null,
 ) {
     /**
-     * Really means "keep the downloader card mounted". STATUS_FAILED is in here because the card
-     * carries the error text and the retry button, and STATUS_PAUSED because a paused download
-     * holds up the whole sequential queue and so has to stay visible and cancellable.
+     * Really means "keep the downloader card on screen". Failed and paused are in here because the
+     * card carries the error and the cancel button, and a paused item holds up everything behind
+     * it.
      */
     val isDownloading: Boolean
         get() =

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
@@ -10,9 +10,13 @@ import dev.jdtech.jellyfin.models.FindroidItem
 import dev.jdtech.jellyfin.models.FindroidSourceType
 import dev.jdtech.jellyfin.models.isDownloading
 import dev.jdtech.jellyfin.utils.Downloader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import javax.inject.Inject
 import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -27,8 +31,10 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
     val events = eventsChannel.receiveAsFlow()
 
     var downloadId: Long? = null
+    var downloadItem: FindroidItem? = null
 
     private val handler = Handler(Looper.getMainLooper())
+    private var itemsDownloaderJob: Job? = null
 
     fun update(item: FindroidItem) {
         viewModelScope.launch {
@@ -62,6 +68,78 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
         }
     }
 
+    private fun downloadMany(items: List<FindroidItem>, storageIndex: Int) {
+        // Safeguard against launching two download jobs at once
+        if (itemsDownloaderJob?.isActive == true) {
+            return
+        }
+
+        // Using Default dispatcher because there is no reason to run this on the UI-thread
+        itemsDownloaderJob = viewModelScope.launch(Dispatchers.Default) {
+            _state.emit(DownloaderState(status = DownloadManager.STATUS_PENDING))
+            items.forEachIndexed { index, item ->
+                _state.emit(
+                    DownloaderState(
+                        status = DownloadManager.STATUS_RUNNING,
+                        progress = index.toFloat() / items.size,
+                    )
+                )
+
+                // If already downloaded skip
+                if (item.sources.any { src -> src.type == FindroidSourceType.LOCAL }) {
+                    // return to the for-loop level to match a continue statement
+                    return@forEachIndexed
+                }
+
+                val (downloadId, uiText) =
+                    downloader.downloadItem(
+                        item = item,
+                        sourceId = item.sources.first().id,
+                        storageIndex = storageIndex,
+                    )
+
+                if (downloadId == -1L) {
+                    _state.emit(
+                        DownloaderState(status = DownloadManager.STATUS_FAILED, errorText = uiText)
+                    )
+                    // Trigger rendering updated badges in UI by sending an event. Which event
+                    // doesn't matter.
+                    eventsChannel.trySend(DownloaderEvent.Successful)
+                    return@launch
+                }
+
+                // Keep track so we can cancel the download
+                this@DownloaderViewModel.downloadItem = item
+                this@DownloaderViewModel.downloadId = downloadId
+                var status = DownloadManager.STATUS_RUNNING
+                while (status == DownloadManager.STATUS_RUNNING || status == DownloadManager.STATUS_PENDING || status == DownloadManager.STATUS_PAUSED) {
+                    // Check download status. UI renders progress on the per item level,
+                    // so there is nothing to emit. We are only waiting for this item to finish
+                    // downloading.
+                    delay(100L)
+                    status = downloader.getProgress(downloadId).first
+                }
+
+                if (status == DownloadManager.STATUS_FAILED) {
+                    // Download failed. Emit the failed state to the ser and terminate the loop.
+                    _state.emit(
+                        DownloaderState(status = DownloadManager.STATUS_FAILED, errorText = uiText)
+                    )
+                    // Trigger rendering updated badges in UI by sending an event. Which event
+                    // doesn't matter.
+                    eventsChannel.trySend(DownloaderEvent.Successful)
+                    return@launch
+                }
+            }
+
+            _state.emit(
+                DownloaderState(status = DownloadManager.STATUS_SUCCESSFUL)
+            )
+            // Trigger rendering updated badges in UI.
+            eventsChannel.trySend(DownloaderEvent.Successful)
+        }
+    }
+
     private fun cancelDownload(item: FindroidItem) {
         viewModelScope.launch {
             // Stop progress polling
@@ -75,6 +153,25 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
         }
     }
 
+    private fun cancelDownloadMany() {
+        viewModelScope.launch(Dispatchers.Default) {
+            // Stop the download job
+            itemsDownloaderJob?.cancel("User pressed cancel button")
+
+            // Cancel the download
+            downloadId?.let { downloadId ->
+                downloadItem?.let { downloadItem ->
+                    downloader.cancelDownload(item = downloadItem, downloadId = downloadId)
+                }
+            }
+
+            // Emit empty DownloadState
+            _state.emit(DownloaderState())
+            // Send event to trigger reload
+            eventsChannel.send(DownloaderEvent.Deleted)
+        }
+    }
+
     private fun deleteDownload(item: FindroidItem) {
         viewModelScope.launch {
             downloader.deleteItem(
@@ -83,6 +180,13 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
             )
             eventsChannel.send(DownloaderEvent.Deleted)
         }
+    }
+
+    private fun deleteDownloadedMany(items: List<FindroidItem>) {
+        // Only if a source has type local can it be deleted
+        items
+            .filter { ep -> ep.sources.any { src -> src.type == FindroidSourceType.LOCAL } }
+            .forEach(::deleteDownload)
     }
 
     private fun pollDownloadProgress(downloadId: Long?) {
@@ -115,13 +219,17 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
     fun onAction(action: DownloaderAction) {
         when (action) {
             is DownloaderAction.Download -> download(action.item, action.storageIndex)
+            is DownloaderAction.DownloadMany -> downloadMany(action.items, action.storageIndex)
             is DownloaderAction.DeleteDownload -> deleteDownload(action.item)
+            is DownloaderAction.DeleteDownloadMany -> deleteDownloadedMany(action.items)
             is DownloaderAction.CancelDownload -> cancelDownload(action.item)
+            DownloaderAction.CancelDownloadMany -> cancelDownloadMany()
         }
     }
 
     override fun onCleared() {
         super.onCleared()
         handler.removeCallbacksAndMessages(null)
+        itemsDownloaderJob?.cancel("onCleared")
     }
 }

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
@@ -6,24 +6,31 @@ import android.os.Looper
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.jdtech.jellyfin.models.FindroidEpisode
 import dev.jdtech.jellyfin.models.FindroidItem
 import dev.jdtech.jellyfin.models.FindroidSourceType
 import dev.jdtech.jellyfin.models.isDownloading
+import dev.jdtech.jellyfin.utils.DownloadEntry
+import dev.jdtech.jellyfin.utils.DownloadEntryStatus
+import dev.jdtech.jellyfin.utils.DownloadQueue
+import dev.jdtech.jellyfin.utils.DownloadRequest
 import dev.jdtech.jellyfin.utils.Downloader
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import dev.jdtech.jellyfin.utils.SubmitOutcome
+import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.Runnable
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
-class DownloaderViewModel @Inject constructor(private val downloader: Downloader) : ViewModel() {
+class DownloaderViewModel
+@Inject
+constructor(private val downloader: Downloader, private val downloadQueue: DownloadQueue) :
+    ViewModel() {
     private val _state = MutableStateFlow(DownloaderState())
     val state = _state.asStateFlow()
 
@@ -31,10 +38,11 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
     val events = eventsChannel.receiveAsFlow()
 
     var downloadId: Long? = null
-    var downloadItem: FindroidItem? = null
 
     private val handler = Handler(Looper.getMainLooper())
-    private var itemsDownloaderJob: Job? = null
+
+    /** Set while this view model is following a queued item instead of polling one itself. */
+    private var queueJob: Job? = null
 
     fun update(item: FindroidItem) {
         viewModelScope.launch {
@@ -50,11 +58,30 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
 
     private fun download(item: FindroidItem, storageIndex: Int = 0) {
         viewModelScope.launch {
+            val sourceId = item.sources.firstOrNull()?.id ?: return@launch
+
+            // Reads the preference itself and hands back Bypassed when sequential downloads are
+            // off, so with the setting off this path is exactly what it was before.
+            val outcome =
+                downloadQueue.submit(
+                    listOf(
+                        DownloadRequest(
+                            item = item,
+                            sourceId = sourceId,
+                            storageIndex = storageIndex,
+                        )
+                    )
+                )
+            if (outcome is SubmitOutcome.Queued) {
+                follow(item.id)
+                return@launch
+            }
+
             _state.emit(DownloaderState(status = DownloadManager.STATUS_PENDING))
             val (downloadId, uiText) =
                 downloader.downloadItem(
                     item = item,
-                    sourceId = item.sources.first().id,
+                    sourceId = sourceId,
                     storageIndex = storageIndex,
                 )
             if (downloadId != -1L) {
@@ -68,75 +95,127 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
         }
     }
 
-    private fun downloadMany(items: List<FindroidItem>, storageIndex: Int) {
-        // Safeguard against launching two download jobs at once
-        if (itemsDownloaderJob?.isActive == true) {
-            return
-        }
-
-        // Using Default dispatcher because there is no reason to run this on the UI-thread
-        itemsDownloaderJob = viewModelScope.launch(Dispatchers.Default) {
-            _state.emit(DownloaderState(status = DownloadManager.STATUS_PENDING))
-            items.forEachIndexed { index, item ->
-                _state.emit(
-                    DownloaderState(
-                        status = DownloadManager.STATUS_RUNNING,
-                        progress = index.toFloat() / items.size,
-                    )
-                )
-
-                // If already downloaded skip
-                if (item.sources.any { src -> src.type == FindroidSourceType.LOCAL }) {
-                    // return to the for-loop level to match a continue statement
-                    return@forEachIndexed
-                }
-
-                val (downloadId, uiText) =
-                    downloader.downloadItem(
-                        item = item,
-                        sourceId = item.sources.first().id,
-                        storageIndex = storageIndex,
-                    )
-
-                if (downloadId == -1L) {
-                    _state.emit(
-                        DownloaderState(status = DownloadManager.STATUS_FAILED, errorText = uiText)
-                    )
-                    // Trigger rendering updated badges in UI by sending an event. Which event
-                    // doesn't matter.
-                    eventsChannel.trySend(DownloaderEvent.Successful)
-                    return@launch
-                }
-
-                // Keep track so we can cancel the download
-                this@DownloaderViewModel.downloadItem = item
-                this@DownloaderViewModel.downloadId = downloadId
-                var status = DownloadManager.STATUS_RUNNING
-                while (status == DownloadManager.STATUS_RUNNING || status == DownloadManager.STATUS_PENDING || status == DownloadManager.STATUS_PAUSED) {
-                    // Check download status. UI renders progress on the per item level,
-                    // so there is nothing to emit. We are only waiting for this item to finish
-                    // downloading.
-                    delay(100L)
-                    status = downloader.getProgress(downloadId).first
-                }
-
-                if (status == DownloadManager.STATUS_FAILED) {
-                    // Download failed. Emit the failed state to the ser and terminate the loop.
-                    _state.emit(
-                        DownloaderState(status = DownloadManager.STATUS_FAILED, errorText = uiText)
-                    )
-                    // Trigger rendering updated badges in UI by sending an event. Which event
-                    // doesn't matter.
-                    eventsChannel.trySend(DownloaderEvent.Successful)
-                    return@launch
+    /**
+     * Reports what the queue says about [itemId], rather than polling DownloadManager. The queue is
+     * the only thing that knows an item is waiting its turn, which DownloadManager cannot express:
+     * it has not been handed the download yet.
+     */
+    private fun follow(itemId: UUID) {
+        handler.removeCallbacksAndMessages(null)
+        queueJob?.cancel()
+        queueJob =
+            viewModelScope.launch {
+                downloadQueue.state.collect { snapshot ->
+                    val entry = snapshot.entries.firstOrNull { it.itemId == itemId }
+                    if (entry == null) {
+                        // Cancelled, or pruned long after finishing. Either way there is nothing
+                        // left to report.
+                        _state.emit(DownloaderState())
+                        return@collect
+                    }
+                    _state.emit(entry.toDownloaderState(snapshot.entries))
+                    if (entry.status == DownloadEntryStatus.SUCCEEDED) {
+                        eventsChannel.trySend(DownloaderEvent.Successful)
+                    }
                 }
             }
+    }
 
-            _state.emit(
-                DownloaderState(status = DownloadManager.STATUS_SUCCESSFUL)
-            )
-            // Trigger rendering updated badges in UI.
+    /**
+     * Submits a whole season as one batch, in episode order, so the episodes a viewer will watch
+     * first are the ones that finish first.
+     */
+    private fun downloadMany(items: List<FindroidItem>, storageIndex: Int = 0) {
+        viewModelScope.launch {
+            val pending =
+                items
+                    .filterNot { item -> item.sources.any { it.type == FindroidSourceType.LOCAL } }
+                    .sortedWith(
+                        compareBy(
+                            { (it as? FindroidEpisode)?.parentIndexNumber ?: 0 },
+                            { (it as? FindroidEpisode)?.indexNumber ?: 0 },
+                        )
+                    )
+            val requests =
+                pending.mapNotNull { item ->
+                    item.sources.firstOrNull()?.let { source ->
+                        DownloadRequest(
+                            item = item,
+                            sourceId = source.id,
+                            storageIndex = storageIndex,
+                        )
+                    }
+                }
+            if (requests.isEmpty()) return@launch
+
+            val outcome = downloadQueue.submit(requests)
+            if (outcome is SubmitOutcome.Queued) {
+                followBatch(outcome.batchId)
+                return@launch
+            }
+
+            // Sequential downloads are off, so this behaves like asking for each of them
+            // separately: they all go to DownloadManager and share the connection.
+            _state.emit(DownloaderState(status = DownloadManager.STATUS_PENDING))
+            for (request in requests) {
+                downloader.downloadItem(
+                    item = request.item,
+                    sourceId = request.sourceId,
+                    storageIndex = request.storageIndex,
+                )
+            }
             eventsChannel.trySend(DownloaderEvent.Successful)
+            _state.emit(DownloaderState())
+        }
+    }
+
+    /** Reports the item the batch is working on now, with how far through the batch it is. */
+    private fun followBatch(batchId: UUID) {
+        handler.removeCallbacksAndMessages(null)
+        queueJob?.cancel()
+        queueJob =
+            viewModelScope.launch {
+                downloadQueue.state.collect { snapshot ->
+                    val batch = snapshot.entries.filter { it.batchId == batchId }
+                    if (batch.isEmpty()) {
+                        _state.emit(DownloaderState())
+                        return@collect
+                    }
+                    val active = batch.firstOrNull { !it.status.isTerminal }
+                    if (active == null) {
+                        eventsChannel.trySend(DownloaderEvent.Successful)
+                        _state.emit(DownloaderState())
+                        return@collect
+                    }
+                    _state.emit(active.toDownloaderState(batch))
+                }
+            }
+    }
+
+    private fun deleteDownloadMany(items: List<FindroidItem>) {
+        viewModelScope.launch {
+            items
+                .filter { item -> item.sources.any { it.type == FindroidSourceType.LOCAL } }
+                .forEach { item ->
+                    downloader.deleteItem(
+                        item = item,
+                        source = item.sources.first { it.type == FindroidSourceType.LOCAL },
+                    )
+                }
+            eventsChannel.send(DownloaderEvent.Deleted)
+        }
+    }
+
+    /** Drops the whole batch, including the episodes still waiting behind the one in flight. */
+    private fun cancelDownloadMany() {
+        viewModelScope.launch {
+            handler.removeCallbacksAndMessages(null)
+            queueJob?.cancel()
+            val batchId = downloadQueue.state.value.entries.firstOrNull()?.batchId
+            if (batchId != null) {
+                downloadQueue.cancelBatch(batchId)
+            }
+            _state.emit(DownloaderState())
         }
     }
 
@@ -144,31 +223,18 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
         viewModelScope.launch {
             // Stop progress polling
             handler.removeCallbacksAndMessages(null)
+            queueJob?.cancel()
 
-            // Cancel the download
-            downloadId?.let { downloader.cancelDownload(item = item, downloadId = it) }
-
-            // Emit empty DownloadState
-            _state.emit(DownloaderState())
-        }
-    }
-
-    private fun cancelDownloadMany() {
-        viewModelScope.launch(Dispatchers.Default) {
-            // Stop the download job
-            itemsDownloaderJob?.cancel("User pressed cancel button")
-
-            // Cancel the download
-            downloadId?.let { downloadId ->
-                downloadItem?.let { downloadItem ->
-                    downloader.cancelDownload(item = downloadItem, downloadId = downloadId)
-                }
+            // The queue owns the download when it accepted the item, and cancelling through it
+            // also drops whatever is still waiting behind it.
+            if (downloadQueue.state.value.entries.any { it.itemId == item.id }) {
+                downloadQueue.cancel(setOf(item.id))
+            } else {
+                downloadId?.let { downloader.cancelDownload(item = item, downloadId = it) }
             }
 
             // Emit empty DownloadState
             _state.emit(DownloaderState())
-            // Send event to trigger reload
-            eventsChannel.send(DownloaderEvent.Deleted)
         }
     }
 
@@ -182,13 +248,6 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
         }
     }
 
-    private fun deleteDownloadedMany(items: List<FindroidItem>) {
-        // Only if a source has type local can it be deleted
-        items
-            .filter { ep -> ep.sources.any { src -> src.type == FindroidSourceType.LOCAL } }
-            .forEach(::deleteDownload)
-    }
-
     private fun pollDownloadProgress(downloadId: Long?) {
         handler.removeCallbacksAndMessages(null)
         val downloadProgressRunnable =
@@ -199,7 +258,10 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
                         _state.emit(
                             DownloaderState(
                                 status = status,
-                                progress = progress.coerceAtLeast(0) / 100f,
+                                // takeIf, not coerceAtLeast: -1 means the total size is unknown,
+                                // and clamping it to 0 would draw a download that is moving as one
+                                // stuck at 0%.
+                                progress = progress.takeIf { it >= 0 }?.div(100f),
                             )
                         )
                     }
@@ -221,15 +283,46 @@ class DownloaderViewModel @Inject constructor(private val downloader: Downloader
             is DownloaderAction.Download -> download(action.item, action.storageIndex)
             is DownloaderAction.DownloadMany -> downloadMany(action.items, action.storageIndex)
             is DownloaderAction.DeleteDownload -> deleteDownload(action.item)
-            is DownloaderAction.DeleteDownloadMany -> deleteDownloadedMany(action.items)
+            is DownloaderAction.DeleteDownloadMany -> deleteDownloadMany(action.items)
             is DownloaderAction.CancelDownload -> cancelDownload(action.item)
-            DownloaderAction.CancelDownloadMany -> cancelDownloadMany()
+            is DownloaderAction.CancelDownloadMany -> cancelDownloadMany()
         }
     }
 
     override fun onCleared() {
         super.onCleared()
         handler.removeCallbacksAndMessages(null)
-        itemsDownloaderJob?.cancel("onCleared")
+        queueJob?.cancel()
     }
+}
+
+/**
+ * The state of one queued item, with a count of everything still outstanding beside it.
+ *
+ * The count is deliberately of the whole queue rather than of some batch: an item only waits
+ * because other items are ahead of it, and "3 left" is what explains why nothing appears to be
+ * happening to this one yet.
+ */
+internal fun DownloadEntry.toDownloaderState(all: List<DownloadEntry>): DownloaderState {
+    val status =
+        when (status) {
+            DownloadEntryStatus.RUNNING -> DownloadManager.STATUS_RUNNING
+            DownloadEntryStatus.PAUSED -> DownloadManager.STATUS_PAUSED
+            DownloadEntryStatus.SUCCEEDED -> DownloadManager.STATUS_SUCCESSFUL
+            DownloadEntryStatus.FAILED -> DownloadManager.STATUS_FAILED
+            // QUEUED or PREPARING: accepted, but no bytes are moving for it yet.
+            else -> DownloadManager.STATUS_PENDING
+        }
+    val outstanding = all.count { !it.status.isTerminal }
+    val done = all.count { it.status == DownloadEntryStatus.SUCCEEDED }
+    val counted = all.size > 1
+    return DownloaderState(
+        status = status,
+        // -1 means the total size is unknown, which is not the same as no progress.
+        progress = progress.takeIf { it >= 0 }?.div(100f)?.coerceIn(0f, 1f),
+        bytesDownloaded = bytesDownloaded,
+        errorText = errorText,
+        itemsCompleted = (done + 1).coerceAtMost(all.size).takeIf { counted && outstanding > 0 },
+        itemsTotal = all.size.takeIf { counted && outstanding > 0 },
+    )
 }

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
@@ -37,6 +37,12 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
     private val eventsChannel = Channel<DownloaderEvent>()
     val events = eventsChannel.receiveAsFlow()
 
+    /**
+     * The queue as a whole, for lists that want to show which of their items are waiting. A screen
+     * showing one item wants [state]; a screen showing many wants this.
+     */
+    val queue = downloadQueue.state
+
     var downloadId: Long? = null
 
     private val handler = Handler(Looper.getMainLooper())

--- a/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/core/presentation/downloader/DownloaderViewModel.kt
@@ -37,10 +37,7 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
     private val eventsChannel = Channel<DownloaderEvent>()
     val events = eventsChannel.receiveAsFlow()
 
-    /**
-     * The queue as a whole, for lists that want to show which of their items are waiting. A screen
-     * showing one item wants [state]; a screen showing many wants this.
-     */
+    /** For lists showing many items. A screen showing one item wants [state] instead. */
     val queue = downloadQueue.state
 
     var downloadId: Long? = null
@@ -66,8 +63,7 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
         viewModelScope.launch {
             val sourceId = item.sources.firstOrNull()?.id ?: return@launch
 
-            // Reads the preference itself and hands back Bypassed when sequential downloads are
-            // off, so with the setting off this path is exactly what it was before.
+            // Hands back Bypassed when the preference is off, leaving the old path untouched.
             val outcome =
                 downloadQueue.submit(
                     listOf(
@@ -102,9 +98,8 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
     }
 
     /**
-     * Reports what the queue says about [itemId], rather than polling DownloadManager. The queue is
-     * the only thing that knows an item is waiting its turn, which DownloadManager cannot express:
-     * it has not been handed the download yet.
+     * Follows the queue rather than polling DownloadManager, which cannot report an item waiting
+     * its turn because it has not been handed the download yet.
      */
     private fun follow(itemId: UUID) {
         handler.removeCallbacksAndMessages(null)
@@ -114,8 +109,7 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
                 downloadQueue.state.collect { snapshot ->
                     val entry = snapshot.entries.firstOrNull { it.itemId == itemId }
                     if (entry == null) {
-                        // Cancelled, or pruned long after finishing. Either way there is nothing
-                        // left to report.
+                        // Cancelled, or pruned after finishing.
                         _state.emit(DownloaderState())
                         return@collect
                     }
@@ -127,10 +121,7 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
             }
     }
 
-    /**
-     * Submits a whole season as one batch, in episode order, so the episodes a viewer will watch
-     * first are the ones that finish first.
-     */
+    /** Submits a season as one batch in episode order, so the earliest episodes finish first. */
     private fun downloadMany(items: List<FindroidItem>, storageIndex: Int = 0) {
         viewModelScope.launch {
             val pending =
@@ -160,8 +151,7 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
                 return@launch
             }
 
-            // Sequential downloads are off, so this behaves like asking for each of them
-            // separately: they all go to DownloadManager and share the connection.
+            // Off, so this matches asking for each separately: they all share the connection.
             _state.emit(DownloaderState(status = DownloadManager.STATUS_PENDING))
             for (request in requests) {
                 downloader.downloadItem(
@@ -264,9 +254,8 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
                         _state.emit(
                             DownloaderState(
                                 status = status,
-                                // takeIf, not coerceAtLeast: -1 means the total size is unknown,
-                                // and clamping it to 0 would draw a download that is moving as one
-                                // stuck at 0%.
+                                // takeIf, not coerceAtLeast: clamping the unknown size to 0 draws
+                                // a moving download as one stuck at 0%.
                                 progress = progress.takeIf { it >= 0 }?.div(100f),
                             )
                         )
@@ -302,13 +291,7 @@ constructor(private val downloader: Downloader, private val downloadQueue: Downl
     }
 }
 
-/**
- * The state of one queued item, with a count of everything still outstanding beside it.
- *
- * The count is deliberately of the whole queue rather than of some batch: an item only waits
- * because other items are ahead of it, and "3 left" is what explains why nothing appears to be
- * happening to this one yet.
- */
+/** One queued item, with a count of what is outstanding to explain why it is waiting. */
 internal fun DownloadEntry.toDownloaderState(all: List<DownloadEntry>): DownloaderState {
     val status =
         when (status) {

--- a/core/src/main/java/dev/jdtech/jellyfin/di/DownloadQueueModule.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/di/DownloadQueueModule.kt
@@ -1,0 +1,52 @@
+package dev.jdtech.jellyfin.di
+
+import android.app.Application
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dev.jdtech.jellyfin.database.ServerDatabaseDao
+import dev.jdtech.jellyfin.repository.JellyfinRepository
+import dev.jdtech.jellyfin.settings.domain.AppPreferences
+import dev.jdtech.jellyfin.utils.DatabaseDownloadedSources
+import dev.jdtech.jellyfin.utils.DownloadForegroundService
+import dev.jdtech.jellyfin.utils.DownloadQueue
+import dev.jdtech.jellyfin.utils.DownloadQueueImpl
+import dev.jdtech.jellyfin.utils.DatabaseDownloadQueueStore
+import dev.jdtech.jellyfin.utils.QueuedItemLoader
+import dev.jdtech.jellyfin.utils.QueuedItemType
+import dev.jdtech.jellyfin.utils.Downloader
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DownloadQueueModule {
+    @Singleton
+    @Provides
+    fun provideDownloadQueue(
+        application: Application,
+        serverDatabase: ServerDatabaseDao,
+        appPreferences: AppPreferences,
+        downloader: Downloader,
+        jellyfinRepository: JellyfinRepository,
+    ): DownloadQueue {
+        return DownloadQueueImpl(
+            downloader = downloader,
+            sources = DatabaseDownloadedSources(serverDatabase),
+            store = DatabaseDownloadQueueStore(serverDatabase),
+            // The queue keeps only an id across a restart, so the item is fetched again here.
+            // Both lookups fall back to the downloaded copy when the server no longer has it.
+            loadItem =
+                QueuedItemLoader { itemId, type ->
+                    when (type) {
+                        QueuedItemType.EPISODE -> jellyfinRepository.getEpisode(itemId)
+                        QueuedItemType.MOVIE -> jellyfinRepository.getMovie(itemId)
+                    }
+                },
+            isSequentialEnabled = {
+                appPreferences.getValue(appPreferences.downloadSequential)
+            },
+            onWorkAccepted = { DownloadForegroundService.start(application) },
+        )
+    }
+}

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadForegroundService.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadForegroundService.kt
@@ -1,0 +1,150 @@
+package dev.jdtech.jellyfin.utils
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import dagger.hilt.android.AndroidEntryPoint
+import dev.jdtech.jellyfin.core.R as CoreR
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Keeps the process alive and visible while the download queue has work.
+ *
+ * Without it the queue is ordinary background work: the system is free to freeze the process once
+ * the app is not on screen, which stops the queue advancing to the next item, and the download it
+ * is waiting on gets no scheduling priority. That matters more here than it would elsewhere,
+ * because a transcode cannot be resumed — the server answers `Accept-Ranges: none`, so an
+ * interrupted transcode is not continued but started over or failed outright.
+ */
+@AndroidEntryPoint
+class DownloadForegroundService : Service() {
+    @Inject lateinit var downloadQueue: DownloadQueue
+
+    private val scope = SupervisorJob().let { CoroutineScope(it + Dispatchers.Main.immediate) }
+    private var observer: Job? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Post the notification before anything else: the system kills a foreground service that
+        // has not shown one within a few seconds of being started.
+        startForegroundWith(getString(CoreR.string.download_pending))
+
+        if (observer == null) {
+            observer =
+                scope.launch {
+                    downloadQueue.state.collect { snapshot ->
+                        val live = snapshot.entries.filterNot { it.status.isTerminal }
+                        if (live.isEmpty()) {
+                            // Nothing left to do; hanging around would hold a notification and a
+                            // wake-lock-shaped process for no reason.
+                            stopSelf()
+                            return@collect
+                        }
+                        val current = live.firstOrNull { it.status != DownloadEntryStatus.QUEUED }
+                        startForegroundWith(
+                            text = current?.name ?: live.first().name,
+                            progress = current?.progress ?: -1,
+                            remaining = live.size,
+                        )
+                    }
+                }
+        }
+        // Redeliver so the queue keeps being watched if the system restarts us.
+        return START_STICKY
+    }
+
+    private fun startForegroundWith(text: String, progress: Int = -1, remaining: Int = 0) {
+        val notification = buildNotification(text, progress, remaining)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceCompat.startForeground(
+                    this,
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, 0)
+            }
+        } catch (e: Exception) {
+            // Starting a foreground service is refused outright in some states, e.g. when the app
+            // was launched from the background. Downloads still run, just without the protection.
+            Timber.e(e, "Could not start the download foreground service")
+        }
+    }
+
+    private fun buildNotification(text: String, progress: Int, remaining: Int): Notification {
+        val manager = getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                        CHANNEL_ID,
+                        getString(CoreR.string.download_notification_channel),
+                        // Low: this is a progress report, not something to interrupt anyone for.
+                        NotificationManager.IMPORTANCE_LOW,
+                    )
+                    .apply { setShowBadge(false) }
+            )
+        }
+        val title =
+            if (remaining > 1) {
+                getString(CoreR.string.download_notification_title_many, remaining)
+            } else {
+                getString(CoreR.string.download_notification_title)
+            }
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(CoreR.drawable.ic_download)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .apply {
+                // A transcode reports no size, so there is no honest percentage to draw.
+                if (progress in 0..100) setProgress(100, progress, false)
+                else setProgress(0, 0, true)
+            }
+            .build()
+    }
+
+    override fun onDestroy() {
+        observer?.cancel()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "downloads"
+        private const val NOTIFICATION_ID = 4815
+
+        /** Safe to call repeatedly; the service ignores a start it is already serving. */
+        fun start(context: Context) {
+            val intent = Intent(context, DownloadForegroundService::class.java)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Could not start the download foreground service")
+            }
+        }
+    }
+}

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadForegroundService.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadForegroundService.kt
@@ -23,13 +23,10 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
- * Keeps the process alive and visible while the download queue has work.
+ * Keeps the process alive while the queue has work.
  *
- * Without it the queue is ordinary background work: the system is free to freeze the process once
- * the app is not on screen, which stops the queue advancing to the next item, and the download it
- * is waiting on gets no scheduling priority. That matters more here than it would elsewhere,
- * because a transcode cannot be resumed — the server answers `Accept-Ranges: none`, so an
- * interrupted transcode is not continued but started over or failed outright.
+ * Without it the system is free to freeze the process once the app leaves the screen. The download
+ * in flight survives, since DownloadManager owns it, but nothing behind it ever starts.
  */
 @AndroidEntryPoint
 class DownloadForegroundService : Service() {
@@ -41,8 +38,7 @@ class DownloadForegroundService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // Post the notification before anything else: the system kills a foreground service that
-        // has not shown one within a few seconds of being started.
+        // First: the system kills a foreground service that has not shown a notification.
         startForegroundWith(getString(CoreR.string.download_pending))
 
         if (observer == null) {
@@ -51,8 +47,7 @@ class DownloadForegroundService : Service() {
                     downloadQueue.state.collect { snapshot ->
                         val live = snapshot.entries.filterNot { it.status.isTerminal }
                         if (live.isEmpty()) {
-                            // Nothing left to do; hanging around would hold a notification and a
-                            // wake-lock-shaped process for no reason.
+                            // Nothing left to do, so stop holding a notification.
                             stopSelf()
                             return@collect
                         }
@@ -83,8 +78,8 @@ class DownloadForegroundService : Service() {
                 ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, 0)
             }
         } catch (e: Exception) {
-            // Starting a foreground service is refused outright in some states, e.g. when the app
-            // was launched from the background. Downloads still run, just without the protection.
+            // Refused outright in some states, such as a start from the background. Downloads
+            // still run, only without the protection.
             Timber.e(e, "Could not start the download foreground service")
         }
     }
@@ -116,7 +111,7 @@ class DownloadForegroundService : Service() {
             .setSilent(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .apply {
-                // A transcode reports no size, so there is no honest percentage to draw.
+                // No total size means no honest percentage to draw.
                 if (progress in 0..100) setProgress(100, progress, false)
                 else setProgress(0, 0, true)
             }

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueue.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueue.kt
@@ -1,0 +1,96 @@
+package dev.jdtech.jellyfin.utils
+
+import dev.jdtech.jellyfin.models.FindroidItem
+import dev.jdtech.jellyfin.models.UiText
+import java.util.UUID
+import kotlinx.coroutines.flow.StateFlow
+
+/** One item the queue has been asked to fetch. */
+data class DownloadRequest(
+    val item: FindroidItem,
+    val sourceId: String,
+    val storageIndex: Int = 0,
+)
+
+enum class DownloadEntryStatus {
+    /** Accepted, not yet handed to [Downloader.downloadItem]. */
+    QUEUED,
+
+    /** Inside [Downloader.downloadItem]: media source lookup, DB writes, trickplay tiles. */
+    PREPARING,
+    RUNNING,
+    PAUSED,
+    SUCCEEDED,
+    FAILED;
+
+    val isTerminal: Boolean
+        get() = this == SUCCEEDED || this == FAILED
+}
+
+data class DownloadEntry(
+    val batchId: UUID,
+    val itemId: UUID,
+    val sourceId: String,
+    val name: String,
+    val status: DownloadEntryStatus,
+    /** 0..100, or -1 while the total size is still unknown. */
+    val progress: Int = -1,
+    /** Bytes on disk so far; the only honest progress signal when [progress] is -1. */
+    val bytesDownloaded: Long = 0,
+    val downloadId: Long? = null,
+    val errorText: UiText? = null,
+)
+
+data class DownloadQueueState(
+    val entries: List<DownloadEntry> = emptyList(),
+    /** Accepted item count per batch, so a shrinking batch still renders "n of total". */
+    val batchTotals: Map<UUID, Int> = emptyMap(),
+)
+
+sealed interface SubmitOutcome {
+    /**
+     * The sequential downloads preference is off. Nothing was queued and the queue was not touched
+     * at all; the caller downloads directly, exactly as it does today.
+     */
+    data object Bypassed : SubmitOutcome
+
+    /**
+     * [isNewBatch] is false when every request was already live in an earlier batch and
+     * [batchId] therefore identifies that pre-existing batch rather than one this call created.
+     * Callers must not assume ownership of a batch they did not create.
+     */
+    data class Queued(val batchId: UUID, val accepted: Int, val isNewBatch: Boolean = true) :
+        SubmitOutcome
+}
+
+/**
+ * App scoped, strictly one at a time download queue. Only ever used when the sequential downloads
+ * preference is enabled — see [submit].
+ *
+ * Serialization has to happen here rather than in the system DownloadManager: DownloadManager runs
+ * everything it has been handed concurrently, so the only way to give one item the full bandwidth
+ * is to delay the `enqueue` call for item N+1 until item N reaches a terminal status.
+ */
+interface DownloadQueue {
+    val state: StateFlow<DownloadQueueState>
+
+    /**
+     * Rebuilds the queue saved by a previous run and picks the work back up. Call once at startup.
+     * Without it the rest of a season is lost whenever the process dies, and re-adding it fetches a
+     * second copy of whatever was already in flight.
+     */
+    fun resume()
+
+    /**
+     * Reads the sequential downloads preference at call time. When it is off this returns
+     * [SubmitOutcome.Bypassed] and does nothing else. Otherwise [requests] are appended in the
+     * given order as one batch; items already live in the queue are skipped.
+     */
+    suspend fun submit(requests: List<DownloadRequest>): SubmitOutcome
+
+    /** Removes [itemIds] from the queue, cancelling any in flight DownloadManager job. */
+    suspend fun cancel(itemIds: Set<UUID>)
+
+    /** Removes every entry belonging to [batchId]. */
+    suspend fun cancelBatch(batchId: UUID)
+}

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueue.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueue.kt
@@ -16,7 +16,7 @@ enum class DownloadEntryStatus {
     /** Accepted, not yet handed to [Downloader.downloadItem]. */
     QUEUED,
 
-    /** Inside [Downloader.downloadItem]: media source lookup, DB writes, trickplay tiles. */
+    /** Inside [Downloader.downloadItem], which is not instant: it also writes rows and images. */
     PREPARING,
     RUNNING,
     PAUSED,
@@ -33,9 +33,8 @@ data class DownloadEntry(
     val sourceId: String,
     val name: String,
     val status: DownloadEntryStatus,
-    /** 0..100, or -1 while the total size is still unknown. */
+    /** 0..100, or -1 when the total size is unknown. */
     val progress: Int = -1,
-    /** Bytes on disk so far; the only honest progress signal when [progress] is -1. */
     val bytesDownloaded: Long = 0,
     val downloadId: Long? = null,
     val errorText: UiText? = null,
@@ -48,43 +47,36 @@ data class DownloadQueueState(
 )
 
 sealed interface SubmitOutcome {
-    /**
-     * The sequential downloads preference is off. Nothing was queued and the queue was not touched
-     * at all; the caller downloads directly, exactly as it does today.
-     */
+    /** The preference is off. Nothing was queued; the caller downloads directly as before. */
     data object Bypassed : SubmitOutcome
 
     /**
-     * [isNewBatch] is false when every request was already live in an earlier batch and
-     * [batchId] therefore identifies that pre-existing batch rather than one this call created.
-     * Callers must not assume ownership of a batch they did not create.
+     * [isNewBatch] is false when every request was already live, so [batchId] identifies the batch
+     * that already owns them rather than one this call created.
      */
     data class Queued(val batchId: UUID, val accepted: Int, val isNewBatch: Boolean = true) :
         SubmitOutcome
 }
 
 /**
- * App scoped, strictly one at a time download queue. Only ever used when the sequential downloads
- * preference is enabled — see [submit].
+ * App scoped, strictly one at a time download queue, used only when the sequential preference is on.
  *
- * Serialization has to happen here rather than in the system DownloadManager: DownloadManager runs
- * everything it has been handed concurrently, so the only way to give one item the full bandwidth
- * is to delay the `enqueue` call for item N+1 until item N reaches a terminal status.
+ * Serialising has to happen here rather than in DownloadManager, which runs everything it is handed
+ * at once: the only way to give one item the full bandwidth is to hold back the next enqueue until
+ * the current item reaches a terminal status.
  */
 interface DownloadQueue {
     val state: StateFlow<DownloadQueueState>
 
     /**
-     * Rebuilds the queue saved by a previous run and picks the work back up. Call once at startup.
-     * Without it the rest of a season is lost whenever the process dies, and re-adding it fetches a
-     * second copy of whatever was already in flight.
+     * Rebuilds the queue saved by a previous run. Call once at startup: without it everything past
+     * the item in flight is lost when the process dies.
      */
     fun resume()
 
     /**
-     * Reads the sequential downloads preference at call time. When it is off this returns
-     * [SubmitOutcome.Bypassed] and does nothing else. Otherwise [requests] are appended in the
-     * given order as one batch; items already live in the queue are skipped.
+     * Reads the preference at call time, returning [SubmitOutcome.Bypassed] when it is off.
+     * Otherwise [requests] are appended in order as one batch, skipping items already queued.
      */
     suspend fun submit(requests: List<DownloadRequest>): SubmitOutcome
 

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueImpl.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueImpl.kt
@@ -24,13 +24,9 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
- * Because the sequential preference being off bypasses the queue entirely (see
- * [DownloadQueue.submit]), the queue is unconditionally sequential: at most one download is ever in
- * flight, which means the dispatcher coroutine can double as the progress poller.
- *
- * The queue is mirrored into [DownloadQueueStore] so it survives the process dying. Without that a
- * season download lost everything past the episode in flight, and re-adding it fetched a second
- * copy of that episode, because nothing was left that remembered the first.
+ * Strictly one at a time, which lets the dispatcher coroutine double as the progress
+ * poller. Mirrored into [DownloadQueueStore] so a restart does not lose everything behind
+ * the item in flight, and does not fetch a second copy of the item that was.
  */
 class DownloadQueueImpl(
     private val downloader: Downloader,
@@ -77,7 +73,6 @@ class DownloadQueueImpl(
             get() = Triple(status, downloadId, retries)
     }
 
-    /** What the dispatcher should do with an entry it has picked up. */
     private sealed interface Work {
         val entry: Entry
 
@@ -105,8 +100,7 @@ class DownloadQueueImpl(
         scope.launch {
             while (true) {
                 wake.receive()
-                // Per iteration containment: one thrown exception must never wedge the dispatcher
-                // for the rest of the process lifetime.
+                // One thrown exception must not wedge the dispatcher for the rest of the process.
                 try {
                     drain()
                 } catch (e: CancellationException) {
@@ -138,14 +132,12 @@ class DownloadQueueImpl(
         val persisted = withContext(ioDispatcher) { store.load() }
         if (persisted.isEmpty()) return
 
-        // A batch with nothing left to do is history. Keeping it would put a finished season's
-        // card back on screen at every launch.
+        // A batch with nothing left to do is history, and would otherwise reappear at every launch.
         val liveBatches =
             persisted.filterNot { it.status.isTerminal }.mapTo(mutableSetOf()) { it.batchId }
         val (keep, drop) = persisted.partition { it.batchId in liveBatches }
         forget(drop.map { it.itemId })
 
-        // Rehydrating goes to the repository, so it happens before the lock is taken.
         val rebuilt =
             keep.mapNotNull { row ->
                 val item = runCatching { loadItem.load(row.itemId, row.itemType) }.getOrNull()
@@ -175,15 +167,14 @@ class DownloadQueueImpl(
         val adopted = mutableListOf<Entry>()
         mutex.withLock {
             for ((entry, batchTotal) in rebuilt) {
-                // Anything submitted since the process came up wins: it is newer, and its download
-                // may already be running.
+                // Anything submitted since startup wins; its download may already be running.
                 if (entries.containsKey(entry.itemId)) continue
                 entries[entry.itemId] = entry
                 batchTotals[entry.batchId] = batchTotal
                 adopted += entry
             }
-            // Taken from every restored row rather than only the adopted ones: handing the same
-            // position out twice would put a newly submitted item ahead of one already waiting.
+            // From every restored row, not just the adopted ones: a reused position would put a new
+            // item ahead of one already waiting.
             nextPosition = maxOf(nextPosition, rebuilt.maxOf { it.first.position } + 1)
             if (adopted.isEmpty()) return@withLock
             publishLocked()
@@ -200,8 +191,8 @@ class DownloadQueueImpl(
     private suspend fun reconcile(entry: Entry) {
         if (entry.status.isTerminal || entry.status == DownloadEntryStatus.QUEUED) return
 
-        // PREPARING means the process died inside downloadItem, which enqueues with DownloadManager
-        // before it writes the sources row. That row is the only record of whether it got that far.
+        // PREPARING means the process died inside downloadItem, which enqueues before it writes the
+        // sources row. That row is the only record of whether it got that far.
         val downloadId =
             entry.downloadId
                 ?: withContext(ioDispatcher) { sources.downloadIdFor(entry.itemId, entry.sourceId) }
@@ -209,7 +200,6 @@ class DownloadQueueImpl(
 
         when {
             info != null && !info.status.isFinishedDownload -> {
-                // Still going, or paused: adopt it and let the dispatcher watch it.
                 entry.downloadId = downloadId
                 entry.status = DownloadEntryStatus.RUNNING
                 entry.bytesDownloaded = info.bytesDownloaded
@@ -219,8 +209,8 @@ class DownloadQueueImpl(
                 entry.progress = 100
             }
             else -> {
-                // Nothing to adopt and nothing finished on disk, so start it over. A transcode
-                // cannot be resumed anyway, so there is nothing in a partial file worth keeping.
+                // Nothing to adopt and nothing finished on disk, so start it over. A partial file is no
+                // help: the server may not support ranges, and DownloadManager has forgotten the job.
                 entry.downloadId = null
                 entry.progress = -1
                 entry.bytesDownloaded = 0
@@ -230,8 +220,6 @@ class DownloadQueueImpl(
     }
 
     override suspend fun submit(requests: List<DownloadRequest>): SubmitOutcome {
-        // Read per call, never cached: preferences are not reactive in this app, so reading once at
-        // construction would make the toggle require an app restart.
         if (!isSequentialEnabled()) {
             return SubmitOutcome.Bypassed
         }
@@ -265,9 +253,8 @@ class DownloadQueueImpl(
                         batchTotals[batchId] = accepted
                         SubmitOutcome.Queued(batchId, accepted)
                     } else {
-                        // Every request is already live in an earlier batch. A batch id with no
-                        // entries can never gain any and the caller would observe it forever, so
-                        // hand back the batch that actually owns the work.
+                        // Everything asked for is already live. A batch id with no entries would never gain any,
+                        // so hand back the batch that actually owns the work.
                         val owner = requests.firstNotNullOfOrNull { entries[it.item.id] }
                         if (owner != null) {
                             SubmitOutcome.Queued(
@@ -284,8 +271,7 @@ class DownloadQueueImpl(
                 result
             }
         if (outcome is SubmitOutcome.Queued) {
-            // Downloads must keep going with the app off screen, and a transcode cannot be
-            // resumed if the process is frozen and the connection dropped.
+            // Downloads must keep going once the app is off screen, or the queue stops advancing.
             onWorkAccepted()
         }
         wake.trySend(Unit)
@@ -293,8 +279,8 @@ class DownloadQueueImpl(
     }
 
     override suspend fun cancel(itemIds: Set<UUID>) {
-        // Remove under the lock FIRST, so nextWorkLocked() cannot pick a victim and awaitTerminal
-        // sees the identity mismatch and bails out immediately.
+        // Remove under the lock first, so nextWorkLocked cannot pick a victim and awaitTerminal
+        // sees the mismatch and bails out.
         val victims =
             mutex.withLock {
                 val removed = itemIds.mapNotNull { entries.remove(it) }
@@ -305,8 +291,8 @@ class DownloadQueueImpl(
                 forget(removed.map { it.itemId })
                 removed.filterNot { it.status == DownloadEntryStatus.SUCCEEDED }
             }
-        // On the queue's own scope, not the caller's: the view model that asked for the cancel is
-        // usually about to be cleared, and the cleanup must not die with it.
+        // On the queue's scope, not the caller's: the view model asking for the cancel is usually
+        // about to be cleared.
         scope.launch { removeVictims(victims) }
     }
 
@@ -318,30 +304,24 @@ class DownloadQueueImpl(
                 batchTotals.remove(batchId)
                 if (removed.isNotEmpty()) publishLocked()
                 forget(removed.map { it.itemId })
-                // A succeeded entry's file is already on disk, and its sources row still carries
-                // the download id, so cancelDownload() would find it and deleteItem() it. Cancel
-                // means stop, not delete what has already finished.
+                // A succeeded entry's row still carries its download id, so cancelDownload would find the
+                // finished file and delete it. Cancel means stop, not delete what already finished.
                 removed.filterNot { it.status == DownloadEntryStatus.SUCCEEDED }
             }
-        // On the queue's own scope, not the caller's: the view model that asked for the cancel is
-        // usually about to be cleared, and the cleanup must not die with it.
         scope.launch { removeVictims(victims) }
     }
 
     /**
-     * Deliberately does NOT cancel a victim's prepare job. [Downloader.downloadItem] enqueues with
-     * DownloadManager well before it writes the sources row carrying the download id, with
-     * suspending network calls in between — cancelling in that window would strand a full size
-     * file on disk that no database row, and therefore no part of the app, can ever reach.
-     * [prepare] already notices its entry has been removed and cleans the enqueue up itself, so
-     * an in flight entry is simply left to finish and tidy up after itself.
+     * Deliberately does not cancel a victim's prepare job. [Downloader.downloadItem] enqueues
+     * with DownloadManager before it writes the row carrying the download id, so cancelling in
+     * that window strands a full size file nothing can reach. [prepare] cleans up its own
+     * orphan instead.
      */
     private suspend fun removeVictims(victims: List<Entry>) {
         for (victim in victims) {
-            // QUEUED was never handed to downloadItem, so there is nothing of ours to cancel;
-            // skipping it also keeps the fallback lookup from finding a sources row left by some
-            // unrelated, already finished download and deleting it. PREPARING is still inside
-            // downloadItem and is cleaned up by prepare()'s own orphan branch.
+            // QUEUED never reached downloadItem, so there is nothing of ours to cancel, and looking
+            // its id up could match a row left by an unrelated finished download. PREPARING is still
+            // inside downloadItem and cleans up after itself.
             if (
                 victim.status == DownloadEntryStatus.QUEUED ||
                     victim.status == DownloadEntryStatus.PREPARING
@@ -388,11 +368,10 @@ class DownloadQueueImpl(
             } catch (e: Exception) {
                 Timber.e(e, "Download queue entry failed")
             } finally {
-                // Safety net: an entry left non terminal would make nextWorkLocked() hand back the
-                // same entry forever and stall every future download.
+                // An entry left non terminal would be handed back forever and stall the queue.
                 mutex.withLock {
-                    // QUEUED is deliberate: a retry puts the entry back in line, and forcing that
-                    // to FAILED here would mean the retry never happened.
+                    // QUEUED is deliberate: a retry puts the entry back in line, and failing it here would mean
+                    // the retry never happened.
                     if (
                         entries[entry.itemId] === entry &&
                             !entry.status.isTerminal &&
@@ -410,17 +389,15 @@ class DownloadQueueImpl(
         }
     }
 
-    /** Caller holds [mutex]. Flips a chosen entry to PREPARING so it cannot be picked twice. */
+    /** Flips the chosen entry to PREPARING so it cannot be picked twice. */
     private fun nextWorkLocked(): Work? {
         val busy =
             entries.values.firstOrNull {
                 !it.status.isTerminal && it.status != DownloadEntryStatus.QUEUED
             }
         if (busy != null) {
-            // Only reachable for an entry restored from a previous run: in the normal path the
-            // dispatcher is already watching the busy entry and does not come back for more work
-            // until it goes terminal. It is with DownloadManager already, so it must not be
-            // enqueued a second time.
+            // Only reachable for an entry restored from a previous run. It is already with
+            // DownloadManager, so it must be watched rather than enqueued again.
             return busy.downloadId?.let { Work.Resume(busy) }
         }
         return entries.values
@@ -446,9 +423,8 @@ class DownloadQueueImpl(
             return
         }
 
-        // A download for this exact source may already be in flight, left behind by a queue that
-        // died before it could be persisted. Adopting it is what stops a second copy of the same
-        // file being fetched alongside the first.
+        // A download for this source may already be in flight, left by a queue that died before it
+        // was persisted. Adopting it is what prevents a second copy of the same file.
         val inFlight =
             withContext(ioDispatcher) { sources.downloadIdFor(entry.itemId, entry.sourceId) }
         val inFlightStatus = inFlight?.let { downloader.getDownloadInfo(it)?.status }
@@ -517,9 +493,8 @@ class DownloadQueueImpl(
                 } ?: return
 
             val info = downloader.getDownloadInfo(downloadId)
-            // Resolved outside the lock: a null row means DownloadManager has no record of the id,
-            // and only the database can say whether DownloadReceiver already stripped the
-            // ".download" suffix (success) or the job was simply lost.
+            // A null row means DownloadManager has forgotten the id, and only the database can say
+            // whether that was success or a lost job.
             val renamed = if (info == null) isAlreadyDownloaded(entry) else false
 
             val terminal =
@@ -530,8 +505,7 @@ class DownloadQueueImpl(
                         val before = entry.durable
                         applyInfoLocked(entry, info, renamed)
                         publishLocked()
-                        // Only when something worth keeping changed: applyInfoLocked runs on every
-                        // poll, and rewriting an unchanged status once a second is pure churn.
+                        // Only when something durable changed; applyInfoLocked runs every poll.
                         if (before != entry.durable) rememberLocked(entry)
                         entry.status.isTerminal
                     }
@@ -545,7 +519,6 @@ class DownloadQueueImpl(
     private suspend fun isAlreadyDownloaded(entry: Entry): Boolean =
         withContext(ioDispatcher) { sources.isDownloaded(entry.itemId, entry.sourceId) }
 
-    /** Caller holds [mutex]. */
     private fun applyInfoLocked(entry: Entry, info: DownloadInfo?, renamed: Boolean) {
         when {
             info == null && renamed -> {
@@ -562,14 +535,12 @@ class DownloadQueueImpl(
             }
             info.status == DownloadManager.STATUS_FAILED -> {
                 if (entry.retries < MAX_RETRIES && isWorthRetrying(info.reason)) {
-                    // A transcode answers Accept-Ranges: none, so DownloadManager cannot pick up
-                    // where it left off and reports failure instead. Starting over is the only
-                    // way to finish, and beats leaving the item stranded.
+                    // A server without range support cannot be resumed, so DownloadManager reports failure
+                    // rather than continuing. Starting over is the only way to finish it.
                     entry.retries++
                     entry.downloadId = null
                     entry.progress = -1
-                    // A restarted transcode begins from zero; keeping the old count would show
-                    // progress running backwards.
+                    // A restart begins from zero; keeping the old count would run progress backwards.
                     entry.bytesDownloaded = 0
                     entry.status = DownloadEntryStatus.QUEUED
                     Timber.d("Retrying ${entry.item.name}, attempt ${entry.retries}")
@@ -592,10 +563,9 @@ class DownloadQueueImpl(
     }
 
     /**
-     * Drops finished entries once the queue has been idle for a while, so a completed season does
-     * not pin its items for the rest of the process. The grace period matters: clearing the moment
-     * the last entry goes terminal would let StateFlow conflation swallow the terminal snapshot,
-     * and collectors would never see the batch finish.
+     * Drops finished entries once the queue has been idle, so a finished batch does not pin its
+     * items for the rest of the process. The delay matters: clearing the moment the last entry
+     * goes terminal lets StateFlow conflation swallow the snapshot that says so.
      */
     private fun scheduleIdlePrune() {
         pruneJob?.cancel()
@@ -614,13 +584,13 @@ class DownloadQueueImpl(
             }
     }
 
-    /** Caller holds [mutex]. Drops totals for batches that no longer have any entries. */
+    /** Drops totals for batches that no longer have entries. */
     private fun dropOrphanedBatchTotalsLocked() {
         val liveBatches = entries.values.mapTo(mutableSetOf()) { it.batchId }
         batchTotals.keys.retainAll(liveBatches)
     }
 
-    /** Caller holds [mutex]. Drops batches whose entries have all reached a terminal status. */
+    /** Drops batches whose entries have all reached a terminal status. */
     private fun pruneTerminalBatchesLocked(): List<UUID> {
         val liveBatches =
             entries.values.filter { !it.status.isTerminal }.mapTo(mutableSetOf()) { it.batchId }
@@ -630,10 +600,7 @@ class DownloadQueueImpl(
         return dropped
     }
 
-    /**
-     * Losing the mirror costs the ability to resume, not the download itself, so a failure here is
-     * logged and swallowed rather than allowed to take the queue down.
-     */
+    /** Losing the mirror costs resumability, not the download, so this never takes the queue down. */
     private suspend fun rememberLocked(entry: Entry) {
         try {
             withContext(ioDispatcher) {
@@ -670,7 +637,6 @@ class DownloadQueueImpl(
         }
     }
 
-    /** Caller holds [mutex]. */
     private fun publishLocked() {
         _state.value =
             DownloadQueueState(
@@ -693,9 +659,8 @@ class DownloadQueueImpl(
     }
 
     /**
-     * Whether a failure is the kind that starting over could fix. A dropped or truncated
-     * connection is; running out of room, or a destination that has gone away, is not — retrying
-     * those just burns the server's transcode budget to fail the same way.
+     * Whether starting over could fix the failure. A dropped or truncated connection could;
+     * running out of room, or a destination that has gone away, could not.
      */
     private fun isWorthRetrying(reason: Int): Boolean =
         reason == DownloadManager.ERROR_CANNOT_RESUME ||
@@ -711,7 +676,6 @@ class DownloadQueueImpl(
     }
 }
 
-/** Whether DownloadManager considers a download over, one way or the other. */
 private val Int.isFinishedDownload: Boolean
     get() = this == DownloadManager.STATUS_SUCCESSFUL || this == DownloadManager.STATUS_FAILED
 

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueImpl.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueImpl.kt
@@ -1,0 +1,719 @@
+package dev.jdtech.jellyfin.utils
+
+import android.app.DownloadManager
+import dev.jdtech.jellyfin.core.R as CoreR
+import dev.jdtech.jellyfin.models.FindroidEpisode
+import dev.jdtech.jellyfin.models.FindroidItem
+import dev.jdtech.jellyfin.models.UiText
+import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Because the sequential preference being off bypasses the queue entirely (see
+ * [DownloadQueue.submit]), the queue is unconditionally sequential: at most one download is ever in
+ * flight, which means the dispatcher coroutine can double as the progress poller.
+ *
+ * The queue is mirrored into [DownloadQueueStore] so it survives the process dying. Without that a
+ * season download lost everything past the episode in flight, and re-adding it fetched a second
+ * copy of that episode, because nothing was left that remembered the first.
+ */
+class DownloadQueueImpl(
+    private val downloader: Downloader,
+    private val sources: DownloadedSources,
+    private val store: DownloadQueueStore,
+    private val loadItem: QueuedItemLoader,
+    /** Read per submit, never cached: the toggle must take effect without an app restart. */
+    private val isSequentialEnabled: () -> Boolean,
+    /** Raised when work is accepted, so downloads survive the app leaving the screen. */
+    private val onWorkAccepted: () -> Unit,
+    private val scope: CoroutineScope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.Default +
+                CoroutineExceptionHandler { _, e -> Timber.e(e, "Download queue coroutine failed") }
+        ),
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS,
+) : DownloadQueue {
+
+    private class Entry(
+        val batchId: UUID,
+        val item: FindroidItem,
+        val itemType: QueuedItemType,
+        val sourceId: String,
+        val storageIndex: Int,
+        /** Insertion order, held explicitly so queue order can be rebuilt from the database. */
+        val position: Long,
+        var status: DownloadEntryStatus = DownloadEntryStatus.QUEUED,
+        var progress: Int = -1,
+        var bytesDownloaded: Long = 0,
+        var downloadId: Long? = null,
+        var errorText: UiText? = null,
+        var retries: Int = 0,
+    ) {
+        val itemId: UUID
+            get() = item.id
+
+        /**
+         * The parts worth a database write. Progress changes every second and DownloadManager owns
+         * it, so it is deliberately not in here.
+         */
+        val durable: Triple<DownloadEntryStatus, Long?, Int>
+            get() = Triple(status, downloadId, retries)
+    }
+
+    /** What the dispatcher should do with an entry it has picked up. */
+    private sealed interface Work {
+        val entry: Entry
+
+        /** Not started yet: hand it to [Downloader.downloadItem]. */
+        data class Start(override val entry: Entry) : Work
+
+        /** Already with DownloadManager, from before a restart: only watch it finish. */
+        data class Resume(override val entry: Entry) : Work
+    }
+
+    private val mutex = Mutex()
+
+    /** Insertion order IS queue order. Keyed by item id, which is also the dedupe key. */
+    private val entries = LinkedHashMap<UUID, Entry>()
+
+    private val batchTotals = LinkedHashMap<UUID, Int>()
+    private val wake = Channel<Unit>(Channel.CONFLATED)
+    private var pruneJob: Job? = null
+    private var nextPosition = 0L
+
+    private val _state = MutableStateFlow(DownloadQueueState())
+    override val state = _state.asStateFlow()
+
+    init {
+        scope.launch {
+            while (true) {
+                wake.receive()
+                // Per iteration containment: one thrown exception must never wedge the dispatcher
+                // for the rest of the process lifetime.
+                try {
+                    drain()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Download queue drain failed")
+                }
+            }
+        }
+    }
+
+    override fun resume() {
+        scope.launch {
+            try {
+                restore()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Could not restore the download queue")
+            }
+        }
+    }
+
+    /**
+     * Rebuilds the queue from the database and reconciles it with what DownloadManager actually
+     * has, since anything could have happened while the process was dead.
+     */
+    private suspend fun restore() {
+        val persisted = withContext(ioDispatcher) { store.load() }
+        if (persisted.isEmpty()) return
+
+        // A batch with nothing left to do is history. Keeping it would put a finished season's
+        // card back on screen at every launch.
+        val liveBatches =
+            persisted.filterNot { it.status.isTerminal }.mapTo(mutableSetOf()) { it.batchId }
+        val (keep, drop) = persisted.partition { it.batchId in liveBatches }
+        forget(drop.map { it.itemId })
+
+        // Rehydrating goes to the repository, so it happens before the lock is taken.
+        val rebuilt =
+            keep.mapNotNull { row ->
+                val item = runCatching { loadItem.load(row.itemId, row.itemType) }.getOrNull()
+                if (item == null) {
+                    Timber.w("Dropping queued ${row.itemId}: its item could not be loaded")
+                    forget(listOf(row.itemId))
+                    null
+                } else {
+                    Entry(
+                        batchId = row.batchId,
+                        item = item,
+                        itemType = row.itemType,
+                        sourceId = row.sourceId,
+                        storageIndex = row.storageIndex,
+                        position = row.position,
+                        status = row.status,
+                        downloadId = row.downloadId,
+                        retries = row.retries,
+                    ) to row.batchTotal
+                }
+            }
+        if (rebuilt.isEmpty()) return
+
+        // Outside the lock: reconciling asks DownloadManager and the database about each entry.
+        rebuilt.forEach { (entry, _) -> reconcile(entry) }
+
+        val adopted = mutableListOf<Entry>()
+        mutex.withLock {
+            for ((entry, batchTotal) in rebuilt) {
+                // Anything submitted since the process came up wins: it is newer, and its download
+                // may already be running.
+                if (entries.containsKey(entry.itemId)) continue
+                entries[entry.itemId] = entry
+                batchTotals[entry.batchId] = batchTotal
+                adopted += entry
+            }
+            // Taken from every restored row rather than only the adopted ones: handing the same
+            // position out twice would put a newly submitted item ahead of one already waiting.
+            nextPosition = maxOf(nextPosition, rebuilt.maxOf { it.first.position } + 1)
+            if (adopted.isEmpty()) return@withLock
+            publishLocked()
+            adopted.forEach { rememberLocked(it) }
+        }
+
+        if (adopted.any { !it.status.isTerminal }) {
+            onWorkAccepted()
+            wake.trySend(Unit)
+        }
+    }
+
+    /** Works out what really became of a restored entry while the process was gone. */
+    private suspend fun reconcile(entry: Entry) {
+        if (entry.status.isTerminal || entry.status == DownloadEntryStatus.QUEUED) return
+
+        // PREPARING means the process died inside downloadItem, which enqueues with DownloadManager
+        // before it writes the sources row. That row is the only record of whether it got that far.
+        val downloadId =
+            entry.downloadId
+                ?: withContext(ioDispatcher) { sources.downloadIdFor(entry.itemId, entry.sourceId) }
+        val info = downloadId?.let { downloader.getDownloadInfo(it) }
+
+        when {
+            info != null && !info.status.isFinishedDownload -> {
+                // Still going, or paused: adopt it and let the dispatcher watch it.
+                entry.downloadId = downloadId
+                entry.status = DownloadEntryStatus.RUNNING
+                entry.bytesDownloaded = info.bytesDownloaded
+            }
+            isAlreadyDownloaded(entry) -> {
+                entry.status = DownloadEntryStatus.SUCCEEDED
+                entry.progress = 100
+            }
+            else -> {
+                // Nothing to adopt and nothing finished on disk, so start it over. A transcode
+                // cannot be resumed anyway, so there is nothing in a partial file worth keeping.
+                entry.downloadId = null
+                entry.progress = -1
+                entry.bytesDownloaded = 0
+                entry.status = DownloadEntryStatus.QUEUED
+            }
+        }
+    }
+
+    override suspend fun submit(requests: List<DownloadRequest>): SubmitOutcome {
+        // Read per call, never cached: preferences are not reactive in this app, so reading once at
+        // construction would make the toggle require an app restart.
+        if (!isSequentialEnabled()) {
+            return SubmitOutcome.Bypassed
+        }
+        val batchId = UUID.randomUUID()
+        var accepted = 0
+        val outcome =
+            mutex.withLock {
+                pruneJob?.cancel()
+                forget(pruneTerminalBatchesLocked())
+                val added = mutableListOf<Entry>()
+                for (request in requests) {
+                    val existing = entries[request.item.id]
+                    if (existing != null && !existing.status.isTerminal) continue
+                    // put() on an existing key keeps its original position, which is what the
+                    // retry path wants.
+                    val entry =
+                        Entry(
+                            batchId = batchId,
+                            item = request.item,
+                            itemType = request.item.queuedItemType,
+                            sourceId = request.sourceId,
+                            storageIndex = request.storageIndex,
+                            position = nextPosition++,
+                        )
+                    entries[request.item.id] = entry
+                    added += entry
+                    accepted++
+                }
+                val result =
+                    if (accepted > 0) {
+                        batchTotals[batchId] = accepted
+                        SubmitOutcome.Queued(batchId, accepted)
+                    } else {
+                        // Every request is already live in an earlier batch. A batch id with no
+                        // entries can never gain any and the caller would observe it forever, so
+                        // hand back the batch that actually owns the work.
+                        val owner = requests.firstNotNullOfOrNull { entries[it.item.id] }
+                        if (owner != null) {
+                            SubmitOutcome.Queued(
+                                batchId = owner.batchId,
+                                accepted = batchTotals[owner.batchId] ?: 1,
+                                isNewBatch = false,
+                            )
+                        } else {
+                            SubmitOutcome.Bypassed
+                        }
+                    }
+                publishLocked()
+                added.forEach { rememberLocked(it) }
+                result
+            }
+        if (outcome is SubmitOutcome.Queued) {
+            // Downloads must keep going with the app off screen, and a transcode cannot be
+            // resumed if the process is frozen and the connection dropped.
+            onWorkAccepted()
+        }
+        wake.trySend(Unit)
+        return outcome
+    }
+
+    override suspend fun cancel(itemIds: Set<UUID>) {
+        // Remove under the lock FIRST, so nextWorkLocked() cannot pick a victim and awaitTerminal
+        // sees the identity mismatch and bails out immediately.
+        val victims =
+            mutex.withLock {
+                val removed = itemIds.mapNotNull { entries.remove(it) }
+                if (removed.isNotEmpty()) {
+                    dropOrphanedBatchTotalsLocked()
+                    publishLocked()
+                }
+                forget(removed.map { it.itemId })
+                removed.filterNot { it.status == DownloadEntryStatus.SUCCEEDED }
+            }
+        // On the queue's own scope, not the caller's: the view model that asked for the cancel is
+        // usually about to be cleared, and the cleanup must not die with it.
+        scope.launch { removeVictims(victims) }
+    }
+
+    override suspend fun cancelBatch(batchId: UUID) {
+        val victims =
+            mutex.withLock {
+                val removed = entries.values.filter { it.batchId == batchId }
+                removed.forEach { entries.remove(it.itemId) }
+                batchTotals.remove(batchId)
+                if (removed.isNotEmpty()) publishLocked()
+                forget(removed.map { it.itemId })
+                // A succeeded entry's file is already on disk, and its sources row still carries
+                // the download id, so cancelDownload() would find it and deleteItem() it. Cancel
+                // means stop, not delete what has already finished.
+                removed.filterNot { it.status == DownloadEntryStatus.SUCCEEDED }
+            }
+        // On the queue's own scope, not the caller's: the view model that asked for the cancel is
+        // usually about to be cleared, and the cleanup must not die with it.
+        scope.launch { removeVictims(victims) }
+    }
+
+    /**
+     * Deliberately does NOT cancel a victim's prepare job. [Downloader.downloadItem] enqueues with
+     * DownloadManager well before it writes the sources row carrying the download id, with
+     * suspending network calls in between — cancelling in that window would strand a full size
+     * file on disk that no database row, and therefore no part of the app, can ever reach.
+     * [prepare] already notices its entry has been removed and cleans the enqueue up itself, so
+     * an in flight entry is simply left to finish and tidy up after itself.
+     */
+    private suspend fun removeVictims(victims: List<Entry>) {
+        for (victim in victims) {
+            // QUEUED was never handed to downloadItem, so there is nothing of ours to cancel;
+            // skipping it also keeps the fallback lookup from finding a sources row left by some
+            // unrelated, already finished download and deleting it. PREPARING is still inside
+            // downloadItem and is cleaned up by prepare()'s own orphan branch.
+            if (
+                victim.status == DownloadEntryStatus.QUEUED ||
+                    victim.status == DownloadEntryStatus.PREPARING
+            ) {
+                continue
+            }
+            // Prefer the id the queue knows, falling back to the sources row downloadItem wrote.
+            val downloadId =
+                victim.downloadId
+                    ?: withContext(ioDispatcher) {
+                        sources.downloadIdFor(victim.itemId, victim.sourceId)
+                    }
+            if (downloadId != null) {
+                try {
+                    downloader.cancelDownload(victim.item, downloadId)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to cancel download")
+                }
+            }
+        }
+        wake.trySend(Unit)
+    }
+
+    private suspend fun drain() {
+        while (true) {
+            val work =
+                mutex.withLock { nextWorkLocked() }
+                    ?: run {
+                        scheduleIdlePrune()
+                        return
+                    }
+            val entry = work.entry
+            try {
+                if (work is Work.Start) {
+                    // Run prepare in its own child so a failure inside it cannot take the
+                    // dispatcher down with it; join() does not rethrow the child's failure.
+                    scope.launch { prepare(entry) }.join()
+                }
+                awaitTerminal(entry)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Download queue entry failed")
+            } finally {
+                // Safety net: an entry left non terminal would make nextWorkLocked() hand back the
+                // same entry forever and stall every future download.
+                mutex.withLock {
+                    // QUEUED is deliberate: a retry puts the entry back in line, and forcing that
+                    // to FAILED here would mean the retry never happened.
+                    if (
+                        entries[entry.itemId] === entry &&
+                            !entry.status.isTerminal &&
+                            entry.status != DownloadEntryStatus.QUEUED
+                    ) {
+                        entry.status = DownloadEntryStatus.FAILED
+                        if (entry.errorText == null) {
+                            entry.errorText = UiText.StringResource(CoreR.string.download_failed)
+                        }
+                        publishLocked()
+                        rememberLocked(entry)
+                    }
+                }
+            }
+        }
+    }
+
+    /** Caller holds [mutex]. Flips a chosen entry to PREPARING so it cannot be picked twice. */
+    private fun nextWorkLocked(): Work? {
+        val busy =
+            entries.values.firstOrNull {
+                !it.status.isTerminal && it.status != DownloadEntryStatus.QUEUED
+            }
+        if (busy != null) {
+            // Only reachable for an entry restored from a previous run: in the normal path the
+            // dispatcher is already watching the busy entry and does not come back for more work
+            // until it goes terminal. It is with DownloadManager already, so it must not be
+            // enqueued a second time.
+            return busy.downloadId?.let { Work.Resume(busy) }
+        }
+        return entries.values
+            .firstOrNull { it.status == DownloadEntryStatus.QUEUED }
+            ?.also {
+                it.status = DownloadEntryStatus.PREPARING
+                publishLocked()
+            }
+            ?.let { Work.Start(it) }
+    }
+
+    private suspend fun prepare(entry: Entry) {
+        // Re-resolve at dequeue time: the caller's snapshot may be minutes old by now.
+        if (isAlreadyDownloaded(entry)) {
+            mutex.withLock {
+                if (entries[entry.itemId] === entry) {
+                    entry.status = DownloadEntryStatus.SUCCEEDED
+                    entry.progress = 100
+                    publishLocked()
+                    rememberLocked(entry)
+                }
+            }
+            return
+        }
+
+        // A download for this exact source may already be in flight, left behind by a queue that
+        // died before it could be persisted. Adopting it is what stops a second copy of the same
+        // file being fetched alongside the first.
+        val inFlight =
+            withContext(ioDispatcher) { sources.downloadIdFor(entry.itemId, entry.sourceId) }
+        val inFlightStatus = inFlight?.let { downloader.getDownloadInfo(it)?.status }
+        if (inFlight != null && inFlightStatus != null && !inFlightStatus.isFinishedDownload) {
+            mutex.withLock {
+                if (entries[entry.itemId] === entry) {
+                    entry.downloadId = inFlight
+                    entry.status = DownloadEntryStatus.RUNNING
+                    publishLocked()
+                    rememberLocked(entry)
+                }
+            }
+            Timber.d("Adopted the download already running for ${entry.item.name}")
+            return
+        }
+
+        val result =
+            try {
+                downloader.downloadItem(entry.item, entry.sourceId, entry.storageIndex)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e)
+                Pair(-1L, UiText.StringResource(CoreR.string.unknown_error))
+            }
+
+        val orphanId =
+            mutex.withLock {
+                if (entries[entry.itemId] !== entry) {
+                    // Cancelled while preparing. If the enqueue already happened, clean it up.
+                    result.first.takeIf { it != -1L }
+                } else {
+                    if (result.first == -1L) {
+                        entry.status = DownloadEntryStatus.FAILED
+                        entry.errorText =
+                            result.second ?: UiText.StringResource(CoreR.string.unknown_error)
+                    } else {
+                        entry.downloadId = result.first
+                        entry.status = DownloadEntryStatus.RUNNING
+                    }
+                    publishLocked()
+                    rememberLocked(entry)
+                    null
+                }
+            }
+        if (orphanId != null) {
+            try {
+                downloader.cancelDownload(entry.item, orphanId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to clean up orphaned download")
+            }
+        }
+    }
+
+    private suspend fun awaitTerminal(entry: Entry) {
+        while (true) {
+            val downloadId =
+                mutex.withLock {
+                    when {
+                        entries[entry.itemId] !== entry -> null
+                        entry.status.isTerminal -> null
+                        else -> entry.downloadId
+                    }
+                } ?: return
+
+            val info = downloader.getDownloadInfo(downloadId)
+            // Resolved outside the lock: a null row means DownloadManager has no record of the id,
+            // and only the database can say whether DownloadReceiver already stripped the
+            // ".download" suffix (success) or the job was simply lost.
+            val renamed = if (info == null) isAlreadyDownloaded(entry) else false
+
+            val terminal =
+                mutex.withLock {
+                    if (entries[entry.itemId] !== entry) {
+                        true
+                    } else {
+                        val before = entry.durable
+                        applyInfoLocked(entry, info, renamed)
+                        publishLocked()
+                        // Only when something worth keeping changed: applyInfoLocked runs on every
+                        // poll, and rewriting an unchanged status once a second is pure churn.
+                        if (before != entry.durable) rememberLocked(entry)
+                        entry.status.isTerminal
+                    }
+                }
+            if (terminal) return
+
+            delay(pollIntervalMs)
+        }
+    }
+
+    private suspend fun isAlreadyDownloaded(entry: Entry): Boolean =
+        withContext(ioDispatcher) { sources.isDownloaded(entry.itemId, entry.sourceId) }
+
+    /** Caller holds [mutex]. */
+    private fun applyInfoLocked(entry: Entry, info: DownloadInfo?, renamed: Boolean) {
+        when {
+            info == null && renamed -> {
+                entry.status = DownloadEntryStatus.SUCCEEDED
+                entry.progress = 100
+            }
+            info == null -> {
+                entry.status = DownloadEntryStatus.FAILED
+                entry.errorText = UiText.StringResource(CoreR.string.download_failed)
+            }
+            info.status == DownloadManager.STATUS_SUCCESSFUL -> {
+                entry.status = DownloadEntryStatus.SUCCEEDED
+                entry.progress = 100
+            }
+            info.status == DownloadManager.STATUS_FAILED -> {
+                if (entry.retries < MAX_RETRIES && isWorthRetrying(info.reason)) {
+                    // A transcode answers Accept-Ranges: none, so DownloadManager cannot pick up
+                    // where it left off and reports failure instead. Starting over is the only
+                    // way to finish, and beats leaving the item stranded.
+                    entry.retries++
+                    entry.downloadId = null
+                    entry.progress = -1
+                    // A restarted transcode begins from zero; keeping the old count would show
+                    // progress running backwards.
+                    entry.bytesDownloaded = 0
+                    entry.status = DownloadEntryStatus.QUEUED
+                    Timber.d("Retrying ${entry.item.name}, attempt ${entry.retries}")
+                } else {
+                    entry.status = DownloadEntryStatus.FAILED
+                    entry.errorText = UiText.StringResource(CoreR.string.download_failed)
+                }
+            }
+            info.status == DownloadManager.STATUS_PAUSED -> {
+                entry.status = DownloadEntryStatus.PAUSED
+                if (info.progress >= 0) entry.progress = info.progress
+                entry.bytesDownloaded = info.bytesDownloaded
+            }
+            else -> {
+                entry.status = DownloadEntryStatus.RUNNING
+                if (info.progress >= 0) entry.progress = info.progress
+                entry.bytesDownloaded = info.bytesDownloaded
+            }
+        }
+    }
+
+    /**
+     * Drops finished entries once the queue has been idle for a while, so a completed season does
+     * not pin its items for the rest of the process. The grace period matters: clearing the moment
+     * the last entry goes terminal would let StateFlow conflation swallow the terminal snapshot,
+     * and collectors would never see the batch finish.
+     */
+    private fun scheduleIdlePrune() {
+        pruneJob?.cancel()
+        pruneJob =
+            scope.launch {
+                delay(IDLE_PRUNE_DELAY_MS)
+                mutex.withLock {
+                    if (entries.isNotEmpty() && entries.values.all { it.status.isTerminal }) {
+                        val ids = entries.keys.toList()
+                        entries.clear()
+                        batchTotals.clear()
+                        publishLocked()
+                        forget(ids)
+                    }
+                }
+            }
+    }
+
+    /** Caller holds [mutex]. Drops totals for batches that no longer have any entries. */
+    private fun dropOrphanedBatchTotalsLocked() {
+        val liveBatches = entries.values.mapTo(mutableSetOf()) { it.batchId }
+        batchTotals.keys.retainAll(liveBatches)
+    }
+
+    /** Caller holds [mutex]. Drops batches whose entries have all reached a terminal status. */
+    private fun pruneTerminalBatchesLocked(): List<UUID> {
+        val liveBatches =
+            entries.values.filter { !it.status.isTerminal }.mapTo(mutableSetOf()) { it.batchId }
+        val dropped = entries.values.filter { it.batchId !in liveBatches }.map { it.itemId }
+        entries.values.removeAll { it.batchId !in liveBatches }
+        batchTotals.keys.retainAll(liveBatches)
+        return dropped
+    }
+
+    /**
+     * Losing the mirror costs the ability to resume, not the download itself, so a failure here is
+     * logged and swallowed rather than allowed to take the queue down.
+     */
+    private suspend fun rememberLocked(entry: Entry) {
+        try {
+            withContext(ioDispatcher) {
+                store.save(
+                    PersistedQueueEntry(
+                        itemId = entry.itemId,
+                        batchId = entry.batchId,
+                        itemType = entry.itemType,
+                        sourceId = entry.sourceId,
+                        storageIndex = entry.storageIndex,
+                        status = entry.status,
+                        downloadId = entry.downloadId,
+                        retries = entry.retries,
+                        position = entry.position,
+                        batchTotal = batchTotals[entry.batchId] ?: 1,
+                    )
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Could not persist a download queue entry")
+        }
+    }
+
+    private suspend fun forget(itemIds: Collection<UUID>) {
+        if (itemIds.isEmpty()) return
+        try {
+            withContext(ioDispatcher) { itemIds.forEach { store.remove(it) } }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Could not remove download queue entries")
+        }
+    }
+
+    /** Caller holds [mutex]. */
+    private fun publishLocked() {
+        _state.value =
+            DownloadQueueState(
+                entries =
+                    entries.values.map { entry ->
+                        DownloadEntry(
+                            batchId = entry.batchId,
+                            itemId = entry.itemId,
+                            sourceId = entry.sourceId,
+                            name = entry.item.name,
+                            status = entry.status,
+                            progress = entry.progress,
+                            bytesDownloaded = entry.bytesDownloaded,
+                            downloadId = entry.downloadId,
+                            errorText = entry.errorText,
+                        )
+                    },
+                batchTotals = batchTotals.toMap(),
+            )
+    }
+
+    /**
+     * Whether a failure is the kind that starting over could fix. A dropped or truncated
+     * connection is; running out of room, or a destination that has gone away, is not — retrying
+     * those just burns the server's transcode budget to fail the same way.
+     */
+    private fun isWorthRetrying(reason: Int): Boolean =
+        reason == DownloadManager.ERROR_CANNOT_RESUME ||
+            reason == DownloadManager.ERROR_HTTP_DATA_ERROR ||
+            reason == DownloadManager.ERROR_TOO_MANY_REDIRECTS ||
+            reason == DownloadManager.ERROR_UNKNOWN ||
+            reason == 0
+
+    companion object {
+        const val DEFAULT_POLL_INTERVAL_MS = 1_000L
+        const val MAX_RETRIES = 2
+        const val IDLE_PRUNE_DELAY_MS = 30_000L
+    }
+}
+
+/** Whether DownloadManager considers a download over, one way or the other. */
+private val Int.isFinishedDownload: Boolean
+    get() = this == DownloadManager.STATUS_SUCCESSFUL || this == DownloadManager.STATUS_FAILED
+
+private val FindroidItem.queuedItemType: QueuedItemType
+    get() = if (this is FindroidEpisode) QueuedItemType.EPISODE else QueuedItemType.MOVIE

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueStore.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueStore.kt
@@ -5,16 +5,13 @@ import dev.jdtech.jellyfin.models.FindroidDownloadQueueEntryDto
 import dev.jdtech.jellyfin.models.FindroidItem
 import java.util.UUID
 
-/** What kind of item an entry holds, which decides how it is rebuilt after a restart. */
+/** Decides how an entry is rebuilt after a restart. */
 enum class QueuedItemType {
     MOVIE,
     EPISODE,
 }
 
-/**
- * A queue entry reduced to what is worth surviving a restart. Progress is absent on purpose:
- * DownloadManager owns it and it is re-read on restore, so it never has to be written back.
- */
+/** A queue entry reduced to what is worth surviving a restart. */
 data class PersistedQueueEntry(
     val itemId: UUID,
     val batchId: UUID,
@@ -28,7 +25,7 @@ data class PersistedQueueEntry(
     val batchTotal: Int,
 )
 
-/** Where the queue keeps itself so a restart does not lose the rest of a season. */
+/** Where the queue keeps itself between runs. */
 interface DownloadQueueStore {
     /** In queue order. */
     suspend fun load(): List<PersistedQueueEntry>
@@ -39,11 +36,8 @@ interface DownloadQueueStore {
 }
 
 /**
- * Rebuilds the item behind a persisted entry.
- *
- * The queue cannot hold onto the item across a restart: [Downloader.downloadItem] needs a real one,
- * with its media sources, series and season ids, trickplay and images, and a stub would silently
- * write half a download. So only the id and type are stored, and the item is fetched again.
+ * Rebuilds the item behind a persisted entry. Only its id and type are stored, because
+ * [Downloader.downloadItem] needs a real item and a stub would write half a download.
  */
 fun interface QueuedItemLoader {
     /** Null when the item can no longer be found, in which case the entry is dropped. */
@@ -73,10 +67,7 @@ class DatabaseDownloadQueueStore(private val database: ServerDatabaseDao) : Down
 
     override suspend fun remove(itemId: UUID) = database.deleteDownloadQueueEntry(itemId)
 
-    /**
-     * Null for a row this build cannot read, rather than a thrown exception: an enum constant
-     * renamed or removed in a later version must not stop the whole queue from loading.
-     */
+    /** Null rather than throwing, so one unreadable row cannot stop the queue loading. */
     private fun FindroidDownloadQueueEntryDto.toPersistedOrNull(): PersistedQueueEntry? {
         val type = QueuedItemType.entries.firstOrNull { it.name == itemType } ?: return null
         val entryStatus = DownloadEntryStatus.entries.firstOrNull { it.name == status } ?: return null

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueStore.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadQueueStore.kt
@@ -1,0 +1,96 @@
+package dev.jdtech.jellyfin.utils
+
+import dev.jdtech.jellyfin.database.ServerDatabaseDao
+import dev.jdtech.jellyfin.models.FindroidDownloadQueueEntryDto
+import dev.jdtech.jellyfin.models.FindroidItem
+import java.util.UUID
+
+/** What kind of item an entry holds, which decides how it is rebuilt after a restart. */
+enum class QueuedItemType {
+    MOVIE,
+    EPISODE,
+}
+
+/**
+ * A queue entry reduced to what is worth surviving a restart. Progress is absent on purpose:
+ * DownloadManager owns it and it is re-read on restore, so it never has to be written back.
+ */
+data class PersistedQueueEntry(
+    val itemId: UUID,
+    val batchId: UUID,
+    val itemType: QueuedItemType,
+    val sourceId: String,
+    val storageIndex: Int,
+    val status: DownloadEntryStatus,
+    val downloadId: Long?,
+    val retries: Int,
+    val position: Long,
+    val batchTotal: Int,
+)
+
+/** Where the queue keeps itself so a restart does not lose the rest of a season. */
+interface DownloadQueueStore {
+    /** In queue order. */
+    suspend fun load(): List<PersistedQueueEntry>
+
+    suspend fun save(entry: PersistedQueueEntry)
+
+    suspend fun remove(itemId: UUID)
+}
+
+/**
+ * Rebuilds the item behind a persisted entry.
+ *
+ * The queue cannot hold onto the item across a restart: [Downloader.downloadItem] needs a real one,
+ * with its media sources, series and season ids, trickplay and images, and a stub would silently
+ * write half a download. So only the id and type are stored, and the item is fetched again.
+ */
+fun interface QueuedItemLoader {
+    /** Null when the item can no longer be found, in which case the entry is dropped. */
+    suspend fun load(itemId: UUID, type: QueuedItemType): FindroidItem?
+}
+
+class DatabaseDownloadQueueStore(private val database: ServerDatabaseDao) : DownloadQueueStore {
+    override suspend fun load(): List<PersistedQueueEntry> =
+        database.getDownloadQueue().mapNotNull { it.toPersistedOrNull() }
+
+    override suspend fun save(entry: PersistedQueueEntry) {
+        database.insertDownloadQueueEntry(
+            FindroidDownloadQueueEntryDto(
+                itemId = entry.itemId,
+                batchId = entry.batchId,
+                itemType = entry.itemType.name,
+                sourceId = entry.sourceId,
+                storageIndex = entry.storageIndex,
+                status = entry.status.name,
+                downloadId = entry.downloadId,
+                retries = entry.retries,
+                position = entry.position,
+                batchTotal = entry.batchTotal,
+            )
+        )
+    }
+
+    override suspend fun remove(itemId: UUID) = database.deleteDownloadQueueEntry(itemId)
+
+    /**
+     * Null for a row this build cannot read, rather than a thrown exception: an enum constant
+     * renamed or removed in a later version must not stop the whole queue from loading.
+     */
+    private fun FindroidDownloadQueueEntryDto.toPersistedOrNull(): PersistedQueueEntry? {
+        val type = QueuedItemType.entries.firstOrNull { it.name == itemType } ?: return null
+        val entryStatus = DownloadEntryStatus.entries.firstOrNull { it.name == status } ?: return null
+        return PersistedQueueEntry(
+            itemId = itemId,
+            batchId = batchId,
+            itemType = type,
+            sourceId = sourceId,
+            storageIndex = storageIndex,
+            status = entryStatus,
+            downloadId = downloadId,
+            retries = retries,
+            position = position,
+            batchTotal = batchTotal,
+        )
+    }
+}

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadedSources.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadedSources.kt
@@ -1,0 +1,28 @@
+package dev.jdtech.jellyfin.utils
+
+import dev.jdtech.jellyfin.database.ServerDatabaseDao
+import java.util.UUID
+
+/**
+ * The two facts the download queue needs from the database, kept separate from the 78-method DAO so
+ * the queue can be exercised without one.
+ */
+interface DownloadedSources {
+    /** Whether the file for [sourceId] is on disk and finished. */
+    suspend fun isDownloaded(itemId: UUID, sourceId: String): Boolean
+
+    /**
+     * The DownloadManager id recorded for [sourceId], if one was. Recovers the id for a download
+     * that was cancelled after being enqueued but before the queue learned its id.
+     */
+    suspend fun downloadIdFor(itemId: UUID, sourceId: String): Long?
+}
+
+class DatabaseDownloadedSources(private val database: ServerDatabaseDao) : DownloadedSources {
+    // A path still ending in .download is a file DownloadReceiver has not finished with.
+    override suspend fun isDownloaded(itemId: UUID, sourceId: String): Boolean =
+        database.getSources(itemId).any { it.id == sourceId && !it.path.endsWith(".download") }
+
+    override suspend fun downloadIdFor(itemId: UUID, sourceId: String): Long? =
+        database.getSources(itemId).firstOrNull { it.id == sourceId }?.downloadId
+}

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadedSources.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloadedSources.kt
@@ -3,18 +3,11 @@ package dev.jdtech.jellyfin.utils
 import dev.jdtech.jellyfin.database.ServerDatabaseDao
 import java.util.UUID
 
-/**
- * The two facts the download queue needs from the database, kept separate from the 78-method DAO so
- * the queue can be exercised without one.
- */
+/** The two facts the queue needs from the database, kept narrow so it can be tested without one. */
 interface DownloadedSources {
-    /** Whether the file for [sourceId] is on disk and finished. */
     suspend fun isDownloaded(itemId: UUID, sourceId: String): Boolean
 
-    /**
-     * The DownloadManager id recorded for [sourceId], if one was. Recovers the id for a download
-     * that was cancelled after being enqueued but before the queue learned its id.
-     */
+    /** Recovers the id of a download enqueued before the queue learned it, so it can be cancelled. */
     suspend fun downloadIdFor(itemId: UUID, sourceId: String): Long?
 }
 

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/Downloader.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/Downloader.kt
@@ -16,4 +16,22 @@ interface Downloader {
     suspend fun deleteItem(item: FindroidItem, source: FindroidSource)
 
     suspend fun getProgress(downloadId: Long?): Pair<Int, Int>
+
+    /**
+     * Everything DownloadManager knows about one download in a single query, so a queue watching a
+     * download does not have to make three.
+     */
+    suspend fun getDownloadInfo(downloadId: Long): DownloadInfo?
 }
+
+/**
+ * [progress] is 0..100, or -1 while the total size is still unknown. [reason] is DownloadManager's
+ * COLUMN_REASON, which only means anything for a failed or paused download.
+ */
+data class DownloadInfo(
+    val status: Int,
+    val progress: Int,
+    val reason: Int = 0,
+    /** Bytes fetched so far, which is the only progress signal when the total size is unknown. */
+    val bytesDownloaded: Long = 0,
+)

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/Downloader.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/Downloader.kt
@@ -17,21 +17,17 @@ interface Downloader {
 
     suspend fun getProgress(downloadId: Long?): Pair<Int, Int>
 
-    /**
-     * Everything DownloadManager knows about one download in a single query, so a queue watching a
-     * download does not have to make three.
-     */
+    /** Status, progress, failure reason and bytes in one query rather than several. */
     suspend fun getDownloadInfo(downloadId: Long): DownloadInfo?
 }
 
 /**
- * [progress] is 0..100, or -1 while the total size is still unknown. [reason] is DownloadManager's
+ * [progress] is 0..100, or -1 when the total size is unknown. [reason] is DownloadManager's
  * COLUMN_REASON, which only means anything for a failed or paused download.
  */
 data class DownloadInfo(
     val status: Int,
     val progress: Int,
     val reason: Int = 0,
-    /** Bytes fetched so far, which is the only progress signal when the total size is unknown. */
     val bytesDownloaded: Long = 0,
 )

--- a/core/src/main/java/dev/jdtech/jellyfin/utils/DownloaderImpl.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/utils/DownloaderImpl.kt
@@ -210,6 +210,35 @@ class DownloaderImpl(
         File(context.filesDir, "images/${item.id}").deleteRecursively()
     }
 
+    override suspend fun getDownloadInfo(downloadId: Long): DownloadInfo? {
+        val query = DownloadManager.Query().setFilterById(downloadId)
+        downloadManager.query(query).use { cursor ->
+            if (!cursor.moveToFirst()) return null
+            val status = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+            val totalBytes =
+                cursor.getLong(
+                    cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
+                )
+            val downloadedBytes =
+                cursor.getLong(
+                    cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+                )
+            val reason = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+            val progress =
+                when {
+                    status == DownloadManager.STATUS_SUCCESSFUL -> 100
+                    totalBytes > 0 -> downloadedBytes.times(100).div(totalBytes).toInt()
+                    else -> -1
+                }
+            return DownloadInfo(
+                status = status,
+                progress = progress,
+                reason = reason,
+                bytesDownloaded = downloadedBytes,
+            )
+        }
+    }
+
     override suspend fun getProgress(downloadId: Long?): Pair<Int, Int> {
         var downloadStatus = -1
         var progress = -1

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -108,5 +108,10 @@
     <string name="download_pending">Pending…</string>
     <string name="download_paused">Paused</string>
     <string name="download_downloading">Downloading…</string>
+    <string name="download_queued">Queued</string>
+    <string name="download_downloading_size">Downloading… %1$s</string>
+    <string name="download_notification_channel">Downloads</string>
+    <string name="download_notification_title">Downloading</string>
+    <string name="download_notification_title_many">Downloading %1$d items</string>
     <string name="download_failed">Failed to download</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="download_paused">Paused</string>
     <string name="download_downloading">Downloading…</string>
     <string name="download_queued">Queued</string>
+    <string name="download_progress">Downloading… %1$d%%</string>
     <string name="download_downloading_size">Downloading… %1$s</string>
     <string name="download_notification_channel">Downloads</string>
     <string name="download_notification_title">Downloading</string>

--- a/core/src/test/java/dev/jdtech/jellyfin/utils/DownloadQueueFakes.kt
+++ b/core/src/test/java/dev/jdtech/jellyfin/utils/DownloadQueueFakes.kt
@@ -1,0 +1,189 @@
+package dev.jdtech.jellyfin.utils
+
+import dev.jdtech.jellyfin.models.FindroidChapter
+import dev.jdtech.jellyfin.models.FindroidImages
+import dev.jdtech.jellyfin.models.FindroidItem
+import dev.jdtech.jellyfin.models.FindroidSource
+import dev.jdtech.jellyfin.models.FindroidSourceType
+import dev.jdtech.jellyfin.models.UiText
+import java.util.UUID
+
+/** Minimal item; the queue only ever reads its id and name. */
+data class TestItem(
+    override val id: UUID = UUID.randomUUID(),
+    override val name: String = "Episode",
+) : FindroidItem {
+    override val originalTitle: String? = null
+    override val overview: String = ""
+    override val played: Boolean = false
+    override val favorite: Boolean = false
+    override val canPlay: Boolean = true
+    override val canDownload: Boolean = true
+    override val sources: List<FindroidSource> = emptyList()
+    override val runtimeTicks: Long = 0
+    override val playbackPositionTicks: Long = 0
+    override val unplayedItemCount: Int? = null
+    override val images: FindroidImages = FindroidImages()
+    override val chapters: List<FindroidChapter> = emptyList()
+}
+
+fun request(item: TestItem) = DownloadRequest(item = item, sourceId = "source-${item.id}")
+
+/** Records what the queue asked of it, and lets a test steer each download's outcome. */
+class FakeDownloader : Downloader {
+    /** Item ids in the order downloadItem was called for them. */
+    val started = mutableListOf<UUID>()
+
+    /** Item ids the queue asked to cancel. */
+    val cancelled = mutableListOf<UUID>()
+
+    /** How many downloads were in flight at once, at the high-water mark. */
+    var peakConcurrent = 0
+        private set
+
+    private var inFlight = 0
+    private var nextDownloadId = 1L
+
+    /** Per item id: the sequence of statuses getDownloadInfo will report, then the last repeats. */
+    val statuses = mutableMapOf<UUID, MutableList<DownloadInfo>>()
+
+    /** Item ids whose downloadItem call should report a failure to start. */
+    val failToStart = mutableSetOf<UUID>()
+
+    private val idToItem = mutableMapOf<Long, UUID>()
+
+    /** Downloads that exist without the queue having started them, as after a restart. */
+    val externalStatuses = mutableMapOf<Long, DownloadInfo>()
+
+    override suspend fun downloadItem(
+        item: FindroidItem,
+        sourceId: String,
+        storageIndex: Int,
+    ): Pair<Long, UiText?> {
+        started += item.id
+        inFlight++
+        if (inFlight > peakConcurrent) peakConcurrent = inFlight
+        if (item.id in failToStart) {
+            inFlight--
+            return Pair(-1L, null)
+        }
+        val id = nextDownloadId++
+        idToItem[id] = item.id
+        return Pair(id, null)
+    }
+
+    override suspend fun cancelDownload(item: FindroidItem, downloadId: Long) {
+        cancelled += item.id
+    }
+
+    override suspend fun deleteItem(item: FindroidItem, source: FindroidSource) = Unit
+
+    override suspend fun getProgress(downloadId: Long?): Pair<Int, Int> = Pair(0, 0)
+
+    override suspend fun getDownloadInfo(downloadId: Long): DownloadInfo? {
+        externalStatuses[downloadId]?.let {
+            return it
+        }
+        val itemId = idToItem[downloadId] ?: return null
+        val queued = statuses[itemId]
+        val info =
+            when {
+                queued == null -> succeeded()
+                queued.size > 1 -> queued.removeAt(0)
+                else -> queued.first()
+            }
+        if (info.status == android.app.DownloadManager.STATUS_SUCCESSFUL || info.status == FAILED) {
+            inFlight = (inFlight - 1).coerceAtLeast(0)
+        }
+        return info
+    }
+
+    companion object {
+        const val FAILED = android.app.DownloadManager.STATUS_FAILED
+        const val RUNNING = android.app.DownloadManager.STATUS_RUNNING
+
+        fun succeeded() = DownloadInfo(android.app.DownloadManager.STATUS_SUCCESSFUL, 100)
+
+        fun running(progress: Int = 10, bytes: Long = 1_000) =
+            DownloadInfo(RUNNING, progress, bytesDownloaded = bytes)
+
+        fun failed(reason: Int) = DownloadInfo(FAILED, -1, reason)
+    }
+}
+
+/** In-memory stand-in for the two database facts the queue needs. */
+class FakeDownloadedSources(
+    private val downloaded: MutableSet<Pair<UUID, String>> = mutableSetOf(),
+    private val downloadIds: MutableMap<Pair<UUID, String>, Long> = mutableMapOf(),
+) : DownloadedSources {
+    /** Which items had their recorded download id looked up, so tests can be specific. */
+    val downloadIdLookups = mutableListOf<UUID>()
+
+    fun markDownloaded(itemId: UUID, sourceId: String) {
+        downloaded += itemId to sourceId
+    }
+
+    fun recordDownloadId(itemId: UUID, sourceId: String, id: Long) {
+        downloadIds[itemId to sourceId] = id
+    }
+
+    override suspend fun isDownloaded(itemId: UUID, sourceId: String) =
+        (itemId to sourceId) in downloaded
+
+    override suspend fun downloadIdFor(itemId: UUID, sourceId: String): Long? {
+        downloadIdLookups += itemId
+        return downloadIds[itemId to sourceId]
+    }
+}
+
+/** In-memory stand-in for the table the queue mirrors itself into. */
+class FakeDownloadQueueStore(seed: List<PersistedQueueEntry> = emptyList()) : DownloadQueueStore {
+    private val rows = seed.associateByTo(linkedMapOf()) { it.itemId }
+
+    /** Everything currently persisted, in queue order. */
+    val saved: List<PersistedQueueEntry>
+        get() = rows.values.sortedBy { it.position }
+
+    override suspend fun load(): List<PersistedQueueEntry> = saved
+
+    override suspend fun save(entry: PersistedQueueEntry) {
+        rows[entry.itemId] = entry
+    }
+
+    override suspend fun remove(itemId: UUID) {
+        rows.remove(itemId)
+    }
+}
+
+/** Hands back the items a test has registered, and null for anything else. */
+class FakeItemLoader(items: List<TestItem> = emptyList()) : QueuedItemLoader {
+    private val known = items.associateBy { it.id }.toMutableMap()
+
+    fun add(item: TestItem) {
+        known[item.id] = item
+    }
+
+    override suspend fun load(itemId: UUID, type: QueuedItemType) = known[itemId]
+}
+
+/** A persisted row for [item], as a previous run would have left behind. */
+fun persisted(
+    item: TestItem,
+    batchId: UUID,
+    status: DownloadEntryStatus = DownloadEntryStatus.QUEUED,
+    downloadId: Long? = null,
+    position: Long = 0,
+    batchTotal: Int = 1,
+) =
+    PersistedQueueEntry(
+        itemId = item.id,
+        batchId = batchId,
+        itemType = QueuedItemType.EPISODE,
+        sourceId = "source-${item.id}",
+        storageIndex = 0,
+        status = status,
+        downloadId = downloadId,
+        retries = 0,
+        position = position,
+        batchTotal = batchTotal,
+    )

--- a/core/src/test/java/dev/jdtech/jellyfin/utils/DownloadQueueImplTest.kt
+++ b/core/src/test/java/dev/jdtech/jellyfin/utils/DownloadQueueImplTest.kt
@@ -1,0 +1,432 @@
+package dev.jdtech.jellyfin.utils
+
+import android.app.DownloadManager
+import java.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the behaviours that were actually got wrong while this queue was being built: cancelling
+ * deleting finished downloads, an entry reaching the cancel path that had never been started, a
+ * batch of duplicates reported as new, downloads overlapping, and a retry that never happened.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadQueueImplTest {
+
+    /**
+     * The queue's own scope. It shares the test's scheduler and its dispatcher loop never
+     * completes, so it has to be cancelled before the test body ends: runTest drains the scheduler
+     * on the way out and would otherwise never finish.
+     */
+    private var queueScope: TestScope? = null
+
+    private fun TestScope.queue(
+        downloader: FakeDownloader = FakeDownloader(),
+        sources: FakeDownloadedSources = FakeDownloadedSources(),
+        store: FakeDownloadQueueStore = FakeDownloadQueueStore(),
+        loadItem: FakeItemLoader = FakeItemLoader(),
+        sequential: Boolean = true,
+        onWorkAccepted: () -> Unit = {},
+    ): DownloadQueueImpl {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ownScope = TestScope(dispatcher)
+        queueScope = ownScope
+        return DownloadQueueImpl(
+            downloader = downloader,
+            sources = sources,
+            store = store,
+            loadItem = loadItem,
+            isSequentialEnabled = { sequential },
+            onWorkAccepted = onWorkAccepted,
+            scope = ownScope,
+            ioDispatcher = dispatcher,
+            pollIntervalMs = 1,
+        )
+    }
+
+    /**
+     * Advances a bounded amount rather than to idle. Two reasons: some tests deliberately keep a
+     * download running forever, so there is no idle to reach, and advancing to idle would also run
+     * the queue's 30s prune, which clears the very entries being asserted on.
+     */
+    private fun TestScope.settle() {
+        advanceTimeBy(1_000)
+        runCurrent()
+    }
+
+    /**
+     * runTest, with the queue's scope cancelled inside it and in a finally.
+     *
+     * Both details are load bearing. Inside, because runTest drains the shared scheduler on its way
+     * out and the queue's dispatcher loop never completes, so a cancel after the body has returned
+     * is already too late — @After cannot do this job, it runs after the drain has wedged. And in a
+     * finally, because an assertion throwing part way through would otherwise skip the cancel and
+     * turn a plain test failure into the whole run spinning at full CPU until something kills it.
+     */
+    private fun queueTest(body: suspend TestScope.() -> Unit) = runTest {
+        try {
+            body()
+        } finally {
+            queueScope?.cancel()
+            queueScope = null
+        }
+    }
+
+    @Test
+    fun `submitting with sequential off leaves the queue untouched`() = queueTest {
+        val downloader = FakeDownloader()
+        val queue = queue(downloader = downloader, sequential = false)
+
+        val outcome = queue.submit(listOf(request(TestItem())))
+        settle()
+
+        assertEquals(SubmitOutcome.Bypassed, outcome)
+        assertTrue("nothing should have been downloaded", downloader.started.isEmpty())
+        assertTrue("no state should be published", queue.state.value.entries.isEmpty())
+    }
+
+    @Test
+    fun `work accepted raises the foreground service`() = queueTest {
+        var raised = 0
+        val queue = queue(onWorkAccepted = { raised++ })
+
+        queue.submit(listOf(request(TestItem())))
+        settle()
+
+        assertEquals(1, raised)
+    }
+
+    @Test
+    fun `sequential off never raises the foreground service`() = queueTest {
+        var raised = 0
+        val queue = queue(sequential = false, onWorkAccepted = { raised++ })
+
+        queue.submit(listOf(request(TestItem())))
+        settle()
+
+        assertEquals(0, raised)
+    }
+
+    @Test
+    fun `items download one at a time, in the order submitted`() = queueTest {
+        val downloader = FakeDownloader()
+        val items = List(4) { TestItem(name = "Episode $it") }
+        // Each reports running once before finishing, so an overlap would be observable.
+        items.forEach {
+            downloader.statuses[it.id] =
+                mutableListOf(FakeDownloader.running(), FakeDownloader.succeeded())
+        }
+        val queue = queue(downloader = downloader)
+
+        queue.submit(items.map { request(it) })
+        settle()
+
+        assertEquals(items.map { it.id }, downloader.started)
+        assertEquals("downloads must not overlap", 1, downloader.peakConcurrent)
+    }
+
+    @Test
+    fun `an item already on disk is not downloaded again`() = queueTest {
+        val downloader = FakeDownloader()
+        val sources = FakeDownloadedSources()
+        val item = TestItem()
+        sources.markDownloaded(item.id, "source-${item.id}")
+        val queue = queue(downloader = downloader, sources = sources)
+
+        queue.submit(listOf(request(item)))
+        settle()
+
+        assertTrue(downloader.started.isEmpty())
+        assertEquals(DownloadEntryStatus.SUCCEEDED, queue.state.value.entries.single().status)
+    }
+
+    @Test
+    fun `resubmitting live items reports the batch that already owns them`() = queueTest {
+        val downloader = FakeDownloader()
+        val items = List(2) { TestItem() }
+        items.forEach { downloader.statuses[it.id] = mutableListOf(FakeDownloader.running()) }
+        val queue = queue(downloader = downloader)
+
+        val first = queue.submit(items.map { request(it) }) as SubmitOutcome.Queued
+        settle()
+        val second = queue.submit(items.map { request(it) }) as SubmitOutcome.Queued
+        settle()
+
+        assertTrue("the first submit creates the batch", first.isNewBatch)
+        assertFalse("the second must not claim a new batch", second.isNewBatch)
+        assertEquals("and must point at the owning batch", first.batchId, second.batchId)
+    }
+
+    @Test
+    fun `cancelling a batch leaves finished downloads alone`() = queueTest {
+        val downloader = FakeDownloader()
+        val done = TestItem(name = "already finished")
+        val running = TestItem(name = "still going")
+        downloader.statuses[done.id] = mutableListOf(FakeDownloader.succeeded())
+        downloader.statuses[running.id] = mutableListOf(FakeDownloader.running())
+        val queue = queue(downloader = downloader)
+
+        val outcome = queue.submit(listOf(request(done), request(running))) as SubmitOutcome.Queued
+        settle()
+        queue.cancelBatch(outcome.batchId)
+        settle()
+
+        assertFalse(
+            "a succeeded download must never reach cancelDownload, which deletes it",
+            done.id in downloader.cancelled,
+        )
+        assertTrue("the one in flight should be cancelled", running.id in downloader.cancelled)
+    }
+
+    @Test
+    fun `cancelling never touches an item that was only queued`() = queueTest {
+        val downloader = FakeDownloader()
+        val sources = FakeDownloadedSources()
+        val running = TestItem(name = "in flight")
+        val waiting = TestItem(name = "still queued")
+        downloader.statuses[running.id] = mutableListOf(FakeDownloader.running())
+        val queue = queue(downloader = downloader, sources = sources)
+
+        val outcome =
+            queue.submit(listOf(request(running), request(waiting))) as SubmitOutcome.Queued
+        settle()
+        queue.cancelBatch(outcome.batchId)
+        settle()
+
+        assertFalse(
+            "a queued item was never enqueued, so there is nothing of ours to cancel",
+            waiting.id in downloader.cancelled,
+        )
+        assertFalse(
+            "and looking its id up could match an unrelated finished download",
+            waiting.id in sources.downloadIdLookups,
+        )
+    }
+
+    @Test
+    fun `an interrupted download is retried, because a transcode cannot resume`() = queueTest {
+        val downloader = FakeDownloader()
+        val item = TestItem()
+        downloader.statuses[item.id] =
+            mutableListOf(
+                FakeDownloader.failed(DownloadManager.ERROR_CANNOT_RESUME),
+                FakeDownloader.succeeded(),
+            )
+        val queue = queue(downloader = downloader)
+
+        queue.submit(listOf(request(item)))
+        settle()
+
+        assertEquals("it should have been started twice", 2, downloader.started.size)
+        assertEquals(DownloadEntryStatus.SUCCEEDED, queue.state.value.entries.single().status)
+    }
+
+    @Test
+    fun `running out of room is not retried`() = queueTest {
+        val downloader = FakeDownloader()
+        val item = TestItem()
+        downloader.statuses[item.id] =
+            mutableListOf(FakeDownloader.failed(DownloadManager.ERROR_INSUFFICIENT_SPACE))
+        val queue = queue(downloader = downloader)
+
+        queue.submit(listOf(request(item)))
+        settle()
+
+        assertEquals("retrying would fail the same way", 1, downloader.started.size)
+        assertEquals(DownloadEntryStatus.FAILED, queue.state.value.entries.single().status)
+    }
+
+    @Test
+    fun `a failure to start does not stall the rest of the batch`() = queueTest {
+        val downloader = FakeDownloader()
+        val bad = TestItem(name = "cannot start")
+        val good = TestItem(name = "fine")
+        downloader.failToStart += bad.id
+        downloader.statuses[good.id] = mutableListOf(FakeDownloader.succeeded())
+        val queue = queue(downloader = downloader)
+
+        queue.submit(listOf(request(bad), request(good)))
+        settle()
+
+        assertTrue("the queue must move past the one that failed", good.id in downloader.started)
+        val entries = queue.state.value.entries.associateBy { it.itemId }
+        assertEquals(DownloadEntryStatus.FAILED, entries.getValue(bad.id).status)
+        assertEquals(DownloadEntryStatus.SUCCEEDED, entries.getValue(good.id).status)
+    }
+
+    @Test
+    fun `a queue left by a previous run is picked back up`() = queueTest {
+        val downloader = FakeDownloader()
+        val batch = UUID.randomUUID()
+        val waiting = List(3) { TestItem(name = "Episode $it") }
+        val store =
+            FakeDownloadQueueStore(
+                waiting.mapIndexed { index, item ->
+                    persisted(item, batch, position = index.toLong(), batchTotal = 3)
+                }
+            )
+        val queue =
+            queue(downloader = downloader, store = store, loadItem = FakeItemLoader(waiting))
+
+        queue.resume()
+        settle()
+
+        assertEquals(
+            "the whole queue should come back, in its original order",
+            waiting.map { it.id },
+            downloader.started,
+        )
+    }
+
+    @Test
+    fun `a download still in flight from a previous run is adopted, not started again`() = queueTest {
+        val downloader = FakeDownloader()
+        val batch = UUID.randomUUID()
+        val item = TestItem(name = "already downloading")
+        // A previous run got as far as handing this to DownloadManager, which is still working.
+        downloader.externalStatuses[77L] = FakeDownloader.running(bytes = 5_000)
+        val store =
+            FakeDownloadQueueStore(
+                listOf(
+                    persisted(item, batch, status = DownloadEntryStatus.RUNNING, downloadId = 77L)
+                )
+            )
+        val queue =
+            queue(downloader = downloader, store = store, loadItem = FakeItemLoader(listOf(item)))
+
+        queue.resume()
+        settle()
+
+        assertTrue(
+            "re-downloading it would leave two copies of the same file on disk",
+            downloader.started.isEmpty(),
+        )
+        val entry = queue.state.value.entries.single()
+        assertEquals(DownloadEntryStatus.RUNNING, entry.status)
+        assertEquals(77L, entry.downloadId)
+    }
+
+    @Test
+    fun `a batch that already finished does not come back`() = queueTest {
+        val batch = UUID.randomUUID()
+        val done = TestItem(name = "finished last time")
+        val store =
+            FakeDownloadQueueStore(
+                listOf(persisted(done, batch, status = DownloadEntryStatus.SUCCEEDED))
+            )
+        val queue = queue(store = store, loadItem = FakeItemLoader(listOf(done)))
+
+        queue.resume()
+        settle()
+
+        assertTrue(
+            "a completed season must not put its card back on screen at every launch",
+            queue.state.value.entries.isEmpty(),
+        )
+        assertTrue("and its rows should be gone", store.saved.isEmpty())
+    }
+
+    @Test
+    fun `an entry whose item can no longer be loaded is dropped`() = queueTest {
+        val batch = UUID.randomUUID()
+        val gone = TestItem(name = "removed from the server")
+        val store = FakeDownloadQueueStore(listOf(persisted(gone, batch)))
+        // Nothing registered in the loader: the item cannot be rebuilt.
+        val queue = queue(store = store, loadItem = FakeItemLoader())
+
+        queue.resume()
+        settle()
+
+        assertTrue(queue.state.value.entries.isEmpty())
+        assertTrue("it would otherwise be retried forever", store.saved.isEmpty())
+    }
+
+    @Test
+    fun `a queued item is written down so a restart can find it`() = queueTest {
+        val store = FakeDownloadQueueStore()
+        val downloader = FakeDownloader()
+        val items = List(2) { TestItem() }
+        items.forEach { downloader.statuses[it.id] = mutableListOf(FakeDownloader.running()) }
+        val queue = queue(downloader = downloader, store = store)
+
+        queue.submit(items.map { request(it) })
+        settle()
+
+        assertEquals("both items belong in the store", 2, store.saved.size)
+        assertEquals(
+            "and in the order they were submitted",
+            items.map { it.id },
+            store.saved.map { it.itemId },
+        )
+    }
+
+    @Test
+    fun `cancelling a batch clears what was written down`() = queueTest {
+        val store = FakeDownloadQueueStore()
+        val downloader = FakeDownloader()
+        val items = List(2) { TestItem() }
+        items.forEach { downloader.statuses[it.id] = mutableListOf(FakeDownloader.running()) }
+        val queue = queue(downloader = downloader, store = store)
+
+        val outcome = queue.submit(items.map { request(it) }) as SubmitOutcome.Queued
+        settle()
+        queue.cancelBatch(outcome.batchId)
+        settle()
+
+        assertTrue(
+            "a cancelled batch must not come back on the next launch",
+            store.saved.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `a download already in flight is adopted instead of fetched twice`() = queueTest {
+        val downloader = FakeDownloader()
+        val sources = FakeDownloadedSources()
+        val item = TestItem(name = "already in flight")
+        // A previous run handed this to DownloadManager and recorded the id, then died before the
+        // queue could be written down.
+        sources.recordDownloadId(item.id, "source-${item.id}", 99L)
+        downloader.externalStatuses[99L] = FakeDownloader.running(bytes = 2_000)
+        val queue = queue(downloader = downloader, sources = sources)
+
+        queue.submit(listOf(request(item)))
+        settle()
+
+        assertTrue(
+            "starting it again would leave two copies of the same file on disk",
+            downloader.started.isEmpty(),
+        )
+        val entry = queue.state.value.entries.single()
+        assertEquals(DownloadEntryStatus.RUNNING, entry.status)
+        assertEquals(99L, entry.downloadId)
+    }
+
+    @Test
+    fun `cancelling a single item clears what was written down`() = queueTest {
+        val store = FakeDownloadQueueStore()
+        val downloader = FakeDownloader()
+        val item = TestItem()
+        downloader.statuses[item.id] = mutableListOf(FakeDownloader.running())
+        val queue = queue(downloader = downloader, store = store)
+
+        queue.submit(listOf(request(item)))
+        settle()
+        queue.cancel(setOf(item.id))
+        settle()
+
+        assertTrue(
+            "a cancelled item must not come back on the next launch",
+            store.saved.isEmpty(),
+        )
+    }
+}

--- a/core/src/test/java/dev/jdtech/jellyfin/utils/DownloadQueueImplTest.kt
+++ b/core/src/test/java/dev/jdtech/jellyfin/utils/DownloadQueueImplTest.kt
@@ -14,19 +14,11 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/**
- * Covers the behaviours that were actually got wrong while this queue was being built: cancelling
- * deleting finished downloads, an entry reaching the cancel path that had never been started, a
- * batch of duplicates reported as new, downloads overlapping, and a retry that never happened.
- */
+/** Covers the behaviours that were actually got wrong while this queue was being written. */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadQueueImplTest {
 
-    /**
-     * The queue's own scope. It shares the test's scheduler and its dispatcher loop never
-     * completes, so it has to be cancelled before the test body ends: runTest drains the scheduler
-     * on the way out and would otherwise never finish.
-     */
+    /** Cancelled by [queueTest]; see there for why the timing matters. */
     private var queueScope: TestScope? = null
 
     private fun TestScope.queue(
@@ -54,9 +46,8 @@ class DownloadQueueImplTest {
     }
 
     /**
-     * Advances a bounded amount rather than to idle. Two reasons: some tests deliberately keep a
-     * download running forever, so there is no idle to reach, and advancing to idle would also run
-     * the queue's 30s prune, which clears the very entries being asserted on.
+     * Bounded rather than advancing to idle: some tests keep a download running forever, and idle
+     * would also run the 30s prune that clears the entries being asserted on.
      */
     private fun TestScope.settle() {
         advanceTimeBy(1_000)
@@ -64,13 +55,9 @@ class DownloadQueueImplTest {
     }
 
     /**
-     * runTest, with the queue's scope cancelled inside it and in a finally.
-     *
-     * Both details are load bearing. Inside, because runTest drains the shared scheduler on its way
-     * out and the queue's dispatcher loop never completes, so a cancel after the body has returned
-     * is already too late — @After cannot do this job, it runs after the drain has wedged. And in a
-     * finally, because an assertion throwing part way through would otherwise skip the cancel and
-     * turn a plain test failure into the whole run spinning at full CPU until something kills it.
+     * runTest, with the queue's scope cancelled inside it and in a finally. Both are load bearing:
+     * runTest drains the scheduler on the way out and the queue's loop never completes, so @After
+     * is too late, and without the finally a failed assertion wedges the run instead of failing it.
      */
     private fun queueTest(body: suspend TestScope.() -> Unit) = runTest {
         try {
@@ -213,7 +200,7 @@ class DownloadQueueImplTest {
     }
 
     @Test
-    fun `an interrupted download is retried, because a transcode cannot resume`() = queueTest {
+    fun `an interrupted download is retried when it cannot be resumed`() = queueTest {
         val downloader = FakeDownloader()
         val item = TestItem()
         downloader.statuses[item.id] =

--- a/data/schemas/dev.jdtech.jellyfin.database.ServerDatabase/9.json
+++ b/data/schemas/dev.jdtech.jellyfin.database.ServerDatabase/9.json
@@ -1,0 +1,893 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "0d7232bf280ced92a1dd5f5d63f473a1",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `currentServerAddressId` TEXT, `currentUserId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentServerAddressId",
+            "columnName": "currentServerAddressId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currentUserId",
+            "columnName": "currentUserId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "serverAddresses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `address` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_serverAddresses_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_serverAddresses_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `serverId` TEXT NOT NULL, `accessToken` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "movies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT, `name` TEXT NOT NULL, `originalTitle` TEXT, `overview` TEXT NOT NULL, `runtimeTicks` INTEGER NOT NULL, `premiereDate` INTEGER, `communityRating` REAL, `officialRating` TEXT, `status` TEXT NOT NULL, `productionYear` INTEGER, `endDate` INTEGER, `chapters` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "originalTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeTicks",
+            "columnName": "runtimeTicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "premiereDate",
+            "columnName": "premiereDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "communityRating",
+            "columnName": "communityRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "officialRating",
+            "columnName": "officialRating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productionYear",
+            "columnName": "productionYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "shows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT, `name` TEXT NOT NULL, `originalTitle` TEXT, `overview` TEXT NOT NULL, `runtimeTicks` INTEGER NOT NULL, `communityRating` REAL, `officialRating` TEXT, `status` TEXT NOT NULL, `productionYear` INTEGER, `endDate` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "originalTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeTicks",
+            "columnName": "runtimeTicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "communityRating",
+            "columnName": "communityRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "officialRating",
+            "columnName": "officialRating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productionYear",
+            "columnName": "productionYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `name` TEXT NOT NULL, `seriesName` TEXT NOT NULL, `overview` TEXT NOT NULL, `indexNumber` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`seriesId`) REFERENCES `shows`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "indexNumber",
+            "columnName": "indexNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seasons_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seasons_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT, `seasonId` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `name` TEXT NOT NULL, `seriesName` TEXT NOT NULL, `overview` TEXT NOT NULL, `indexNumber` INTEGER NOT NULL, `indexNumberEnd` INTEGER, `parentIndexNumber` INTEGER NOT NULL, `runtimeTicks` INTEGER NOT NULL, `premiereDate` INTEGER, `communityRating` REAL, `chapters` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`seasonId`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seriesId`) REFERENCES `shows`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "indexNumber",
+            "columnName": "indexNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "indexNumberEnd",
+            "columnName": "indexNumberEnd",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "parentIndexNumber",
+            "columnName": "parentIndexNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeTicks",
+            "columnName": "runtimeTicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "premiereDate",
+            "columnName": "premiereDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "communityRating",
+            "columnName": "communityRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodes_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_episodes_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seasonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itemId` TEXT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `path` TEXT NOT NULL, `downloadId` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadId",
+            "columnName": "downloadId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "mediastreams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `displayTitle` TEXT, `language` TEXT NOT NULL, `type` TEXT NOT NULL, `codec` TEXT NOT NULL, `isExternal` INTEGER NOT NULL, `path` TEXT NOT NULL, `channelLayout` TEXT, `videoRangeType` TEXT, `height` INTEGER, `width` INTEGER, `videoDoViTitle` TEXT, `downloadId` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayTitle",
+            "columnName": "displayTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codec",
+            "columnName": "codec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExternal",
+            "columnName": "isExternal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelLayout",
+            "columnName": "channelLayout",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoRangeType",
+            "columnName": "videoRangeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "videoDoViTitle",
+            "columnName": "videoDoViTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadId",
+            "columnName": "downloadId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "userdata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `played` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `playbackPositionTicks` INTEGER NOT NULL, `toBeSynced` INTEGER NOT NULL, PRIMARY KEY(`userId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "played",
+            "columnName": "played",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackPositionTicks",
+            "columnName": "playbackPositionTicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toBeSynced",
+            "columnName": "toBeSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "trickplayInfos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `tileWidth` INTEGER NOT NULL, `tileHeight` INTEGER NOT NULL, `thumbnailCount` INTEGER NOT NULL, `interval` INTEGER NOT NULL, `bandwidth` INTEGER NOT NULL, PRIMARY KEY(`sourceId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tileWidth",
+            "columnName": "tileWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tileHeight",
+            "columnName": "tileHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailCount",
+            "columnName": "thumbnailCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interval",
+            "columnName": "interval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bandwidth",
+            "columnName": "bandwidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "segments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `startTicks` INTEGER NOT NULL, `endTicks` INTEGER NOT NULL, PRIMARY KEY(`itemId`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTicks",
+            "columnName": "startTicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTicks",
+            "columnName": "endTicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId",
+            "type"
+          ]
+        }
+      },
+      {
+        "tableName": "downloadQueue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `batchId` TEXT NOT NULL, `itemType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `storageIndex` INTEGER NOT NULL, `status` TEXT NOT NULL, `downloadId` INTEGER, `retries` INTEGER NOT NULL, `position` INTEGER NOT NULL, `batchTotal` INTEGER NOT NULL, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchId",
+            "columnName": "batchId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemType",
+            "columnName": "itemType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storageIndex",
+            "columnName": "storageIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadId",
+            "columnName": "downloadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "retries",
+            "columnName": "retries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchTotal",
+            "columnName": "batchTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0d7232bf280ced92a1dd5f5d63f473a1')"
+    ]
+  }
+}

--- a/data/src/main/java/dev/jdtech/jellyfin/database/ServerDatabase.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/database/ServerDatabase.kt
@@ -8,6 +8,7 @@ import androidx.room.TypeConverters
 import androidx.room.migration.AutoMigrationSpec
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import dev.jdtech.jellyfin.models.FindroidDownloadQueueEntryDto
 import dev.jdtech.jellyfin.models.FindroidEpisodeDto
 import dev.jdtech.jellyfin.models.FindroidMediaStreamDto
 import dev.jdtech.jellyfin.models.FindroidMovieDto
@@ -36,8 +37,9 @@ import dev.jdtech.jellyfin.models.User
             FindroidUserDataDto::class,
             FindroidTrickplayInfoDto::class,
             FindroidSegmentDto::class,
+            FindroidDownloadQueueEntryDto::class,
         ],
-    version = 8,
+    version = 9,
     autoMigrations =
         [
             AutoMigration(from = 2, to = 3),
@@ -45,6 +47,7 @@ import dev.jdtech.jellyfin.models.User
             AutoMigration(from = 4, to = 5, spec = ServerDatabase.TrickplayMigration::class),
             AutoMigration(from = 5, to = 6, spec = ServerDatabase.IntrosMigration::class),
             AutoMigration(from = 7, to = 8),
+            AutoMigration(from = 8, to = 9),
         ],
 )
 @TypeConverters(Converters::class)

--- a/data/src/main/java/dev/jdtech/jellyfin/database/ServerDatabaseDao.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/database/ServerDatabaseDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import dev.jdtech.jellyfin.models.FindroidDownloadQueueEntryDto
 import dev.jdtech.jellyfin.models.FindroidEpisodeDto
 import dev.jdtech.jellyfin.models.FindroidMediaStreamDto
 import dev.jdtech.jellyfin.models.FindroidMovieDto
@@ -202,6 +203,15 @@ interface ServerDatabaseDao {
 
     @Query("SELECT * FROM segments WHERE itemId = :itemId")
     fun getSegments(itemId: UUID): List<FindroidSegmentDto>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertDownloadQueueEntry(entry: FindroidDownloadQueueEntryDto)
+
+    @Query("SELECT * FROM downloadQueue ORDER BY position ASC")
+    fun getDownloadQueue(): List<FindroidDownloadQueueEntryDto>
+
+    @Query("DELETE FROM downloadQueue WHERE itemId = :itemId")
+    fun deleteDownloadQueueEntry(itemId: UUID)
 
     @Query("SELECT * FROM seasons") fun getSeasons(): List<FindroidSeasonDto>
 

--- a/data/src/main/java/dev/jdtech/jellyfin/models/FindroidDownloadQueueEntryDto.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/models/FindroidDownloadQueueEntryDto.kt
@@ -7,19 +7,15 @@ import java.util.UUID
 /**
  * One item waiting in, or being worked on by, the download queue.
  *
- * Deliberately carries no foreign key to `episodes` or `movies`: a queued item has no row in either
- * table until its download actually starts, so a key would reject the very rows this table exists
- * to keep.
- *
- * Only durable facts live here. Progress and byte counts are left out on purpose — they change
- * every second, and DownloadManager is their real owner, so they are re-read on restore rather than
- * written back constantly.
+ * No foreign key to `episodes` or `movies` on purpose: a queued item has no row in either until its
+ * download starts, so a key would reject the very rows this table exists to keep. Progress is left
+ * out for a similar reason, it changes every second and DownloadManager owns it.
  */
 @Entity(tableName = "downloadQueue")
 data class FindroidDownloadQueueEntryDto(
     @PrimaryKey val itemId: UUID,
     val batchId: UUID,
-    /** Which lookup rebuilds the item on restore: an episode and a movie are fetched differently. */
+    /** Which lookup rebuilds the item on restore, since episodes and movies are fetched apart. */
     val itemType: String,
     val sourceId: String,
     val storageIndex: Int,
@@ -27,11 +23,8 @@ data class FindroidDownloadQueueEntryDto(
     val status: String,
     val downloadId: Long?,
     val retries: Int,
-    /** Insertion order, which is queue order. Episodes must resume in the order they were added. */
+    /** Insertion order, which is queue order. */
     val position: Long,
-    /**
-     * How many items the batch accepted when it was submitted. Stored per row rather than derived
-     * from a count, so cancelling one episode does not quietly renumber "3 of 10" into "3 of 9".
-     */
+    /** Stored rather than counted, so cancelling one episode does not renumber "3 of 10". */
     val batchTotal: Int,
 )

--- a/data/src/main/java/dev/jdtech/jellyfin/models/FindroidDownloadQueueEntryDto.kt
+++ b/data/src/main/java/dev/jdtech/jellyfin/models/FindroidDownloadQueueEntryDto.kt
@@ -1,0 +1,37 @@
+package dev.jdtech.jellyfin.models
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+/**
+ * One item waiting in, or being worked on by, the download queue.
+ *
+ * Deliberately carries no foreign key to `episodes` or `movies`: a queued item has no row in either
+ * table until its download actually starts, so a key would reject the very rows this table exists
+ * to keep.
+ *
+ * Only durable facts live here. Progress and byte counts are left out on purpose — they change
+ * every second, and DownloadManager is their real owner, so they are re-read on restore rather than
+ * written back constantly.
+ */
+@Entity(tableName = "downloadQueue")
+data class FindroidDownloadQueueEntryDto(
+    @PrimaryKey val itemId: UUID,
+    val batchId: UUID,
+    /** Which lookup rebuilds the item on restore: an episode and a movie are fetched differently. */
+    val itemType: String,
+    val sourceId: String,
+    val storageIndex: Int,
+    /** [dev.jdtech.jellyfin.utils.DownloadEntryStatus] by name. */
+    val status: String,
+    val downloadId: Long?,
+    val retries: Int,
+    /** Insertion order, which is queue order. Episodes must resume in the order they were added. */
+    val position: Long,
+    /**
+     * How many items the batch accepted when it was submitted. Stored per row rather than derived
+     * from a count, so cancelling one episode does not quietly renumber "3 of 10" into "3 of 9".
+     */
+    val batchTotal: Int,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ androidx-work = "2.11.2"
 coil = "3.5.0"
 hilt = "2.60.1"
 jellyfin = "1.8.12"
+junit = "4.13.2"
+kotlinx-coroutines = "1.10.2"
 kotlin = "2.4.10"
 kotlinx-serialization = "1.11.0"
 ksp = "2.3.10"
@@ -64,6 +66,8 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 androidx-tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "androidx-tv-material3" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
 androidx-work = { group = "androidx.work", name = "work-runtime", version.ref = "androidx-work" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 coil-network-cache-control = { group = "io.coil-kt.coil3", name = "coil-network-cache-control", version.ref = "coil" }

--- a/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/season/SeasonViewModel.kt
+++ b/modes/film/src/main/java/dev/jdtech/jellyfin/film/presentation/season/SeasonViewModel.kt
@@ -28,7 +28,8 @@ class SeasonViewModel @Inject constructor(private val repository: JellyfinReposi
                     repository.getEpisodes(
                         seriesId = season.seriesId,
                         seasonId = seasonId,
-                        fields = listOf(ItemFields.OVERVIEW),
+                        // MediaSources and CanDownload are necessary for season download logic
+                        fields = listOf(ItemFields.OVERVIEW, ItemFields.CAN_DOWNLOAD, ItemFields.MEDIA_SOURCES),
                     )
                 _state.emit(_state.value.copy(season = season, episodes = episodes))
             } catch (e: Exception) {

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
@@ -82,6 +82,7 @@ class AppPreferences @Inject constructor(val sharedPreferences: SharedPreference
     // Downloads
     val downloadOverMobileData = Preference("pref_downloads_mobile_data", false)
     val downloadWhenRoaming = Preference("pref_downloads_roaming", false)
+    val downloadSequential = Preference("pref_downloads_sequential", false)
 
     // Network
     val requestTimeout =

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/presentation/settings/SettingsViewModel.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/presentation/settings/SettingsViewModel.kt
@@ -643,6 +643,15 @@ class SettingsViewModel @Inject constructor(private val appPreferences: AppPrefe
                                                     backendPreference =
                                                         appPreferences.downloadWhenRoaming,
                                                 ),
+                                                PreferenceSwitch(
+                                                    nameStringResource =
+                                                        R.string.download_sequential,
+                                                    descriptionStringRes =
+                                                        R.string.download_sequential_summary,
+                                                    supportedDeviceTypes = listOf(DeviceType.PHONE),
+                                                    backendPreference =
+                                                        appPreferences.downloadSequential,
+                                                ),
                                             )
                                     )
                                 ),

--- a/settings/src/main/res/values/strings.xml
+++ b/settings/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="download_sequential">Sequential</string>
+    <string name="download_sequential_summary">Download one item at a time, so all bandwidth goes to a single download instead of being shared between several.</string>
     <string name="settings_category_language">Language</string>
     <string name="settings_preferred_audio_language">Preferred audio language</string>
     <string name="settings_preferred_subtitle_language">Preferred subtitle language</string>

--- a/settings/src/main/res/values/strings.xml
+++ b/settings/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="download_sequential">Sequential</string>
-    <string name="download_sequential_summary">Download one item at a time, so all bandwidth goes to a single download instead of being shared between several.</string>
+    <string name="download_sequential_summary">Download one item at a time in order.</string>
     <string name="settings_category_language">Language</string>
     <string name="settings_preferred_audio_language">Preferred audio language</string>
     <string name="settings_preferred_subtitle_language">Preferred subtitle language</string>


### PR DESCRIPTION
Hi, and thanks for Findroid.

This adds an optional **Sequential** setting for downloads, off by default, on top of the whole season download from #1228 by @spacecowboy.

With the setting on, downloads run one at a time in the order they were queued. A season download then finishes the earliest episodes first rather than splitting the connection across all of them, which on a slow link is the difference between having the first few episodes ready and having ten unfinished ones.

<img width="300" alt="The Sequential setting in the download settings" src="https://github.com/user-attachments/assets/7cdde222-bae1-423d-9e81-447fac6666ee" /> <img width="300" alt="A season downloading, with the first episode running and the rest queued" src="https://github.com/user-attachments/assets/cf9fe762-b4c3-47d6-8122-f959f32cd220" />

### What it does

* A Sequential toggle in the download settings, off by default.
* A whole season is submitted as one batch, in episode order.
* The season list shows which episode is downloading and which ones are waiting.
* Downloads keep going while the app is off screen, through a small foreground service.
* The queue is stored, so it survives the process being killed and carries on where it left off.

### Why the queue lives in the app

The system DownloadManager runs everything it is given at once, so the only way to give one item the whole connection is to hold back the next one until the current one reaches a terminal state.

### When the setting is off

`submit()` returns `Bypassed` and a download takes exactly the path it did before, so nothing changes for anyone who does not turn it on.

### On #1228

The season download commit is @spacecowboy's work, kept under his authorship. The loop it introduced is replaced here by the shared queue so that single items and seasons follow the same path. If #1228 lands first I am happy to rebase on it and drop that commit.

### Testing

There are unit tests for the queue. I also ran it on a phone against a deliberately throttled server so the ordering was observable: a season of five episodes queued in episode order, exactly one running with the rest waiting, and each handover happening as the previous episode finished. Killing the app in the middle of a download and reopening it adopted the running download instead of starting a second copy of the same file.

### Transcoded downloads

I have transcoded downloads working on top of this as well, with Jellyfin's own bitrate ladder, a preferred quality setting and quality switching during playback. I left it out here to keep the diff reviewable, but it is on a branch in my fork if it is of interest: https://github.com/genericJE/findroid/tree/feat/transcoded-downloads

Happy to split this up further or change anything you would like done differently.
