### PR TITLE
feat: report playback stopped when using back and forward buttons

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -138,6 +138,8 @@ class PlayerActivity : BasePlayerActivity() {
         val pipButton = binding.playerView.findViewById<ImageButton>(R.id.btn_pip)
         val lockButton = binding.playerView.findViewById<ImageButton>(R.id.btn_lockview)
         val unlockButton = binding.playerView.findViewById<ImageButton>(R.id.btn_unlock)
+        val previousItemButton = binding.playerView.findViewById<ImageButton>(R.id.exo_prev)
+        val nextItemButton = binding.playerView.findViewById<ImageButton>(R.id.exo_next)
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -312,6 +314,9 @@ class PlayerActivity : BasePlayerActivity() {
         }
 
         pipButton.setOnClickListener { pictureInPicture() }
+
+        previousItemButton.setOnClickListener { viewModel.seekToPreviousWithStopReport() }
+        nextItemButton.setOnClickListener { viewModel.seekToNextMediaItemWithStopReport() }
 
         // Set marker color
         val timeBar = binding.playerView.findViewById<DefaultTimeBar>(R.id.exo_progress)

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/utils/PlayerGestureHelper.kt
@@ -167,7 +167,7 @@ class PlayerGestureHelper(
             }
             in rightmostAreaStart until viewWidth -> {
                 if (activity.viewModel.isLastChapter()) {
-                    playerView.player?.seekToNextMediaItem()
+                    activity.viewModel.seekToNextMediaItemWithStopReport()
                     return
                 }
                 activity.viewModel.seekToNextChapter()?.let { chapter -> displayChapter(chapter) }

--- a/player/local/src/main/java/dev/jdtech/jellyfin/player/local/presentation/PlayerViewModel.kt
+++ b/player/local/src/main/java/dev/jdtech/jellyfin/player/local/presentation/PlayerViewModel.kt
@@ -413,22 +413,7 @@ constructor(
                 reason == Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM &&
                 player.playbackState == ExoPlayer.STATE_READY
         ) {
-            viewModelScope.launch {
-                val mediaId = player.currentMediaItem?.mediaId
-                val position = player.currentPosition
-                val duration = player.duration
-                try {
-                    repository.postPlaybackStop(
-                        UUID.fromString(mediaId),
-                        position.times(10000),
-                        position.div(duration.toFloat()).times(100).toInt(),
-                    )
-                } catch (e: Exception) {
-                    Timber.e(e)
-                }
-                player.seekToNextMediaItem()
-                player.play()
-            }
+            moveToNextMediaItem(autoplay = true)
         }
     }
 
@@ -543,11 +528,65 @@ constructor(
 
     fun skipSegment(segment: FindroidSegment) {
         if (shouldSkipToNextEpisode(segment)) {
-            player.seekToNextMediaItem()
+            moveToNextMediaItem(autoplay = false)
         } else {
             player.seekTo(segment.endTicks)
         }
         _uiState.update { it.copy(currentSegment = null) }
+    }
+
+    fun seekToNextMediaItemWithStopReport() {
+        moveToNextMediaItem(autoplay = false)
+    }
+
+    fun seekToPreviousWithStopReport() {
+        viewModelScope.launch(Dispatchers.Main) {
+            val shouldTransitionToPreviousItem =
+                player.hasPreviousMediaItem() &&
+                    player.currentPosition <= player.maxSeekToPreviousPosition
+
+            if (shouldTransitionToPreviousItem) {
+                reportCurrentItemPlaybackStopped()
+            }
+
+            player.seekToPrevious()
+        }
+    }
+
+    private fun moveToNextMediaItem(autoplay: Boolean) {
+        viewModelScope.launch(Dispatchers.Main) {
+            if (!player.hasNextMediaItem()) {
+                return@launch
+            }
+
+            reportCurrentItemPlaybackStopped()
+
+            player.seekToNextMediaItem()
+
+            if (autoplay) {
+                player.play()
+            }
+        }
+    }
+
+    private suspend fun reportCurrentItemPlaybackStopped() {
+        val mediaId = player.currentMediaItem?.mediaId ?: return
+        val position = player.currentPosition
+        val duration = player.duration
+
+        if (duration <= 0L) {
+            return
+        }
+
+        try {
+            repository.postPlaybackStop(
+                UUID.fromString(mediaId),
+                position.times(10000),
+                position.div(duration.toFloat()).times(100).toInt(),
+            )
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
     }
 
     // Check if the outro segment's end time is within n milliseconds of the player's total duration


### PR DESCRIPTION
Fixes missing playback stop reporting when switching episodes with manual controls.

This change reports the currently playing item as stopped before transitioning to another media item when users:
1. Tap next
2. Tap previous (when it actually changes to previous item)
3. Trigger next-item transition from chapter-skip

Fixes #872  
Releated #869  

Should improve compatibility with Jellyfin plugins that rely on PlaybackStopped events during episode transitions.